### PR TITLE
Add trans tags in all templates

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-16 14:13+0000\n"
+"POT-Creation-Date: 2017-08-24 15:24-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,10 +20,20 @@ msgstr ""
 
 #: area/models.py:50 geosite/models.py:42 organization/models.py:43
 #: person/models.py:46 templates/area/search.html:24
-#: templates/area/search.html:84 templates/organization/search.html:22
-#: templates/organization/search.html:162 templates/person/search.html:21
-#: templates/person/search.html:128 templates/site/search.html:23
-#: templates/site/search.html:91
+#: templates/area/search.html:84
+#: templates/organization/create-geography.html:75
+#: templates/organization/create-geography.html:185
+#: templates/organization/detail.html:103
+#: templates/organization/detail.html:154
+#: templates/organization/detail.html:205
+#: templates/organization/detail.html:256
+#: templates/organization/detail.html:307 templates/organization/search.html:22
+#: templates/organization/search.html:162
+#: templates/partials/organization_list_table.html:10
+#: templates/partials/person_list_table.html:13 templates/person/create.html:34
+#: templates/person/create.html:146 templates/person/detail.html:111
+#: templates/person/search.html:21 templates/person/search.html:128
+#: templates/site/search.html:23 templates/site/search.html:91
 msgid "Name"
 msgstr ""
 
@@ -34,7 +44,10 @@ msgstr ""
 #: area/models.py:67 composition/models.py:73 organization/models.py:69
 #: templates/area/search.html:28 templates/area/search.html:85
 #: templates/composition/search.html:97 templates/composition/search.html:140
-#: templates/organization/search.html:30 templates/organization/search.html:164
+#: templates/organization/create.html:76 templates/organization/create.html:179
+#: templates/organization/edit.html:59 templates/organization/search.html:30
+#: templates/organization/search.html:164
+#: templates/partials/organization_list_table.html:26
 msgid "Classification"
 msgstr ""
 
@@ -42,7 +55,8 @@ msgstr ""
 msgid "OSM name"
 msgstr ""
 
-#: area/models.py:86 geosite/models.py:85 violation/models.py:113
+#: area/models.py:86 geosite/models.py:85
+#: templates/organization/create-geography.html:90 violation/models.py:113
 msgid "OSM ID"
 msgstr ""
 
@@ -56,8 +70,10 @@ msgstr ""
 #: templates/composition/search.html:17 templates/composition/search.html:141
 #: templates/emplacement/search.html:23 templates/emplacement/search.html:138
 #: templates/membershipperson/search.html:139
-#: templates/organization/search.html:166 templates/violation/search.html:17
-#: templates/violation/search.html:194 violation/models.py:70
+#: templates/organization/detail.html:311
+#: templates/organization/search.html:166 templates/person/detail.html:67
+#: templates/violation/search.html:17 templates/violation/search.html:194
+#: violation/models.py:70
 msgid "Start date"
 msgstr ""
 
@@ -66,8 +82,10 @@ msgstr ""
 #: templates/composition/search.html:56 templates/composition/search.html:142
 #: templates/emplacement/search.html:62 templates/emplacement/search.html:139
 #: templates/membershipperson/search.html:140
-#: templates/organization/search.html:167 templates/violation/search.html:56
-#: templates/violation/search.html:195 violation/models.py:77
+#: templates/organization/detail.html:312
+#: templates/organization/search.html:167 templates/person/detail.html:68
+#: templates/violation/search.html:56 templates/violation/search.html:195
+#: violation/models.py:77
 msgid "End date"
 msgstr ""
 
@@ -75,12 +93,16 @@ msgstr ""
 #: membershiporganization/models.py:65 membershipperson/models.py:136
 #: templates/association/search.html:109 templates/association/search.html:140
 #: templates/emplacement/search.html:109 templates/emplacement/search.html:140
-#: templates/organization/edit.html:10 templates/violation/search.html:198
+#: templates/membershiporganization/create.html:44
+#: templates/organization/create-geography.html:32
+#: templates/organization/create-geography.html:164
+#: templates/organization/edit.html:10 templates/person/detail.html:63
+#: templates/sidebar.html:10 templates/violation/search.html:198
 msgid "Organization"
 msgstr ""
 
 #: association/models.py:70 templates/association/search.html:117
-#: templates/association/search.html:141
+#: templates/association/search.html:141 templates/sidebar.html:13
 msgid "Area"
 msgstr ""
 
@@ -97,7 +119,8 @@ msgid "Child organization"
 msgstr ""
 
 #: emplacement/models.py:72 templates/emplacement/search.html:117
-#: templates/emplacement/search.html:141 templates/site/edit.html:8
+#: templates/emplacement/search.html:141 templates/sidebar.html:15
+#: templates/site/edit.html:8
 msgid "Site"
 msgstr ""
 
@@ -117,11 +140,17 @@ msgstr ""
 msgid "Coordinates"
 msgstr ""
 
-#: geosite/models.py:101
+#: geosite/models.py:101 templates/organization/detail.html:106
+#: templates/organization/detail.html:157
+#: templates/organization/detail.html:208
+#: templates/organization/detail.html:259
 msgid "First cited"
 msgstr ""
 
-#: geosite/models.py:109
+#: geosite/models.py:109 templates/organization/detail.html:107
+#: templates/organization/detail.html:158
+#: templates/organization/detail.html:209
+#: templates/organization/detail.html:260
 msgid "Last cited"
 msgstr ""
 
@@ -140,17 +169,26 @@ msgid "Last cited date"
 msgstr ""
 
 #: membershipperson/models.py:144 templates/membershipperson/search.html:17
-#: templates/membershipperson/search.html:136 templates/person/edit.html:80
+#: templates/membershipperson/search.html:136
+#: templates/organization/detail.html:309 templates/person/detail.html:65
+#: templates/person/detail.html:113 templates/person/edit.html:80
 msgid "Role"
 msgstr ""
 
-#: membershipperson/models.py:153 templates/membershipperson/search.html:35
-#: templates/membershipperson/search.html:137 templates/person/edit.html:79
+#: membershipperson/models.py:153 templates/membershipperson/create.html:40
+#: templates/membershipperson/edit.html:21
+#: templates/membershipperson/search.html:35
+#: templates/membershipperson/search.html:137
+#: templates/organization/detail.html:310
+#: templates/partials/source_search_results.html:7
+#: templates/person/detail.html:66 templates/person/edit.html:79
 msgid "Title"
 msgstr ""
 
 #: membershipperson/models.py:161 templates/membershipperson/search.html:26
-#: templates/membershipperson/search.html:138 templates/person/edit.html:81
+#: templates/membershipperson/search.html:138
+#: templates/organization/detail.html:308 templates/person/detail.html:64
+#: templates/person/detail.html:112 templates/person/edit.html:81
 msgid "Rank"
 msgstr ""
 
@@ -162,11 +200,13 @@ msgstr ""
 msgid "Real end date"
 msgstr ""
 
-#: membershipperson/models.py:201
+#: membershipperson/models.py:201 templates/membershipperson/create.html:90
+#: templates/membershipperson/edit.html:77
 msgid "Start context"
 msgstr ""
 
-#: membershipperson/models.py:209
+#: membershipperson/models.py:209 templates/membershipperson/create.html:119
+#: templates/membershipperson/edit.html:106
 msgid "End context"
 msgstr ""
 
@@ -199,7 +239,7 @@ msgstr ""
 msgid "Alias"
 msgstr ""
 
-#: person/views.py:402 templates/person/search.html:7
+#: person/views.py:398 templates/person/search.html:7
 msgid "Person"
 msgstr ""
 
@@ -207,19 +247,19 @@ msgstr ""
 msgid "Please add a source for this information"
 msgstr ""
 
-#: sfm_pc/settings.py:148 tests/test_settings.py:127
+#: sfm_pc/settings.py:149 tests/test_settings.py:127
 msgid "French"
 msgstr ""
 
-#: sfm_pc/settings.py:149 tests/test_settings.py:128
+#: sfm_pc/settings.py:150 tests/test_settings.py:128
 msgid "English"
 msgstr ""
 
-#: sfm_pc/settings.py:150 tests/test_settings.py:129
+#: sfm_pc/settings.py:151 tests/test_settings.py:129
 msgid "Spanish"
 msgstr ""
 
-#: sfm_pc/utils.py:353
+#: sfm_pc/utils.py:500
 msgid "Object sources"
 msgstr ""
 
@@ -397,6 +437,7 @@ msgid "E-mail address"
 msgstr ""
 
 #: templates/account/login.html:17 templates/account/login.html:18
+#: templates/login.html:28
 msgid "Password"
 msgstr ""
 
@@ -592,19 +633,43 @@ msgstr ""
 msgid "Area of Operations"
 msgstr ""
 
+#: templates/area/edit.html:13 templates/composition/edit.html:11
+#: templates/composition/search.html:9
+msgid "Add new"
+msgstr ""
+
+#: templates/area/edit.html:19 templates/area/search.html:17
+#: templates/association/edit.html:17 templates/association/search.html:16
+#: templates/composition/edit.html:19 templates/emplacement/edit.html:17
+#: templates/emplacement/search.html:16 templates/site/search.html:16
+msgid "Properties"
+msgstr ""
+
+#: templates/area/edit.html:47 templates/association/edit.html:46
+#: templates/composition/edit.html:57 templates/delete_confirm.html:18
+#: templates/emplacement/edit.html:46 templates/site/edit.html:53
+#: templates/violation/edit.html:170
+msgid "Cancel"
+msgstr ""
+
+#: templates/area/edit.html:48 templates/association/edit.html:47
+#: templates/composition/edit.html:58 templates/emplacement/edit.html:47
+#: templates/partials/organization_merge.html:9
+#: templates/partials/person_merge.html:9 templates/site/edit.html:54
+#: templates/violation/edit.html:171
+msgid "Save"
+msgstr ""
+
 #: templates/area/search.html:8
 msgid "Search Area"
 msgstr ""
 
-#: templates/area/search.html:10 templates/association/search.html:9
-#: templates/emplacement/search.html:9 templates/person/search.html:9
+#: templates/area/search.html:10 templates/association/edit.html:11
+#: templates/association/search.html:9 templates/emplacement/edit.html:11
+#: templates/emplacement/search.html:9 templates/membershipperson/search.html:9
+#: templates/organization/search.html:9 templates/person/search.html:9
 #: templates/site/search.html:9
 msgid "Add New"
-msgstr ""
-
-#: templates/area/search.html:17 templates/association/search.html:16
-#: templates/emplacement/search.html:16 templates/site/search.html:16
-msgid "Properties"
 msgstr ""
 
 #: templates/area/search.html:25 templates/organization/search.html:23
@@ -687,19 +752,21 @@ msgstr ""
 
 #: templates/area/search.html:71 templates/association/search.html:125
 #: templates/composition/search.html:125 templates/emplacement/search.html:125
-#: templates/membershipperson/search.html:123 templates/person/search.html:115
+#: templates/membershipperson/search.html:123
+#: templates/organization/search.html:149 templates/person/search.html:115
 #: templates/site/search.html:78 templates/violation/search.html:181
 msgid "Results"
 msgstr ""
 
 #: templates/area/search.html:73 templates/association/search.html:127
 #: templates/composition/search.html:127 templates/emplacement/search.html:127
-#: templates/membershipperson/search.html:125 templates/person/search.html:117
+#: templates/membershipperson/search.html:125
+#: templates/organization/search.html:151 templates/person/search.html:117
 #: templates/site/search.html:80 templates/violation/search.html:183
 msgid "Export"
 msgstr ""
 
-#: templates/association/edit.html:9
+#: templates/association/edit.html:9 templates/sidebar.html:12
 msgid "Association"
 msgstr ""
 
@@ -707,18 +774,6 @@ msgstr ""
 #: templates/composition/edit.html:47 templates/composition/search.html:114
 #: templates/emplacement/edit.html:36 templates/emplacement/search.html:114
 msgid "With"
-msgstr ""
-
-#: templates/association/edit.html:46 templates/composition/edit.html:57
-#: templates/emplacement/edit.html:46 templates/site/edit.html:53
-#: templates/violation/edit.html:170
-msgid "Cancel"
-msgstr ""
-
-#: templates/association/edit.html:47 templates/composition/edit.html:58
-#: templates/emplacement/edit.html:47 templates/site/edit.html:54
-#: templates/violation/edit.html:171
-msgid "Save"
 msgstr ""
 
 #: templates/association/search.html:7
@@ -907,7 +962,8 @@ msgstr ""
 msgid "yyyy"
 msgstr ""
 
-#: templates/association/search.html:103 templates/emplacement/search.html:103
+#: templates/association/search.html:103 templates/composition/edit.html:37
+#: templates/emplacement/search.html:103
 msgid "Relations"
 msgstr ""
 
@@ -915,16 +971,84 @@ msgstr ""
 msgid "Enter organization name"
 msgstr ""
 
-#: templates/base_modal.html:8 templates/modals/source.html:34
+#: templates/base.html:27
+msgid "A tool from"
+msgstr ""
+
+#: templates/base.html:44
+msgid "Countries"
+msgstr ""
+
+#: templates/base.html:45 templates/partials/nav-wizard.html:7
+#: templates/partials/person_search_results.html:5
+#: templates/person/create.html:15
+msgid "Personnel"
+msgstr ""
+
+#: templates/base.html:46 templates/organization/create.html:14
+#: templates/partials/nav-wizard.html:6
+#: templates/partials/organization_search_results.html:5
+msgid "Units"
+msgstr ""
+
+#: templates/base.html:47 templates/organization/detail.html:45
+#: templates/organization/detail.html:63 templates/organization/detail.html:339
+#: templates/partials/nav-wizard.html:10
+#: templates/partials/violation_search_results.html:5
+msgid "Incidents"
+msgstr ""
+
+#: templates/base.html:48
+msgid "Help"
+msgstr ""
+
+#: templates/base.html:52
+msgid "New source"
+msgstr ""
+
+#: templates/base.html:56
+msgid "Logout"
+msgstr ""
+
+#: templates/base_detail.html:19 templates/base_detail.html:29
+msgid "Contents"
+msgstr ""
+
+#: templates/base_modal.html:10 templates/modals/source.html:34
+#: templates/modals/translate.html:24 templates/modals/version.html:26
 msgid "Close"
 msgstr ""
 
-#: templates/composition/edit.html:9
-msgid "Composition"
+#: templates/composition/create.html:13
+msgid "Unit relationships"
 msgstr ""
 
-#: templates/composition/edit.html:11 templates/composition/search.html:9
-msgid "Add new"
+#: templates/composition/create.html:15
+msgid "Describe how units are related to one another in"
+msgstr ""
+
+#: templates/composition/create.html:27
+msgid "Relationships for"
+msgstr ""
+
+#: templates/composition/create.html:29
+msgid "Remove this relationship"
+msgstr ""
+
+#: templates/composition/create.html:38
+msgid "Relationship type"
+msgstr ""
+
+#: templates/composition/create.html:61
+msgid "Related organization"
+msgstr ""
+
+#: templates/composition/create.html:87
+msgid "Relationship classification"
+msgstr ""
+
+#: templates/composition/edit.html:9 templates/sidebar.html:11
+msgid "Composition"
 msgstr ""
 
 #: templates/composition/search.html:7
@@ -944,6 +1068,7 @@ msgid "Enter child organization"
 msgstr ""
 
 #: templates/composition/search.html:138
+#: templates/partials/organization_list_table.html:18
 msgid "Parent"
 msgstr ""
 
@@ -959,12 +1084,88 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: templates/emplacement/edit.html:9
+#: templates/emplacement/edit.html:9 templates/sidebar.html:14
 msgid "Emplacement"
 msgstr ""
 
 #: templates/emplacement/search.html:7
 msgid "Search Emplacement"
+msgstr ""
+
+#: templates/login.html:26
+msgid "Email address"
+msgstr ""
+
+#: templates/login.html:31
+msgid "Forgot Password?"
+msgstr ""
+
+#: templates/login.html:33
+msgid "Sign in"
+msgstr ""
+
+#: templates/membershiporganization/create.html:17
+msgid "Unit memberships"
+msgstr ""
+
+#: templates/membershiporganization/create.html:19
+msgid "Describe which organizations (if any) are members of one another in"
+msgstr ""
+
+#: templates/membershiporganization/create.html:33
+msgid "Memberships for"
+msgstr ""
+
+#: templates/membershiporganization/create.html:35
+msgid "Remove this membership"
+msgstr ""
+
+#: templates/membershiporganization/create.html:69
+msgid "First & last citation dates"
+msgstr ""
+
+#: templates/membershipperson/create.html:15
+#: templates/partials/nav-wizard.html:8
+msgid "Positions"
+msgstr ""
+
+#: templates/membershipperson/create.html:16
+msgid "Describe positions held by personnel in"
+msgstr ""
+
+#: templates/membershipperson/create.html:55
+#: templates/membershipperson/edit.html:36
+msgid "Role & Rank"
+msgstr ""
+
+#: templates/membershipperson/create.html:58
+#: templates/membershipperson/edit.html:39
+msgid "Select a Role"
+msgstr ""
+
+#: templates/membershipperson/create.html:72
+#: templates/membershipperson/edit.html:56
+msgid "Select a Rank"
+msgstr ""
+
+#: templates/membershipperson/create.html:102
+#: templates/membershipperson/create.html:104
+#: templates/membershipperson/create.html:131
+#: templates/membershipperson/create.html:133
+#: templates/membershipperson/edit.html:89
+#: templates/membershipperson/edit.html:91
+#: templates/membershipperson/edit.html:118
+#: templates/membershipperson/edit.html:120
+msgid "Real context?"
+msgstr ""
+
+#: templates/membershipperson/create.html:148
+#: templates/membershipperson/edit.html:135
+msgid "Citation dates"
+msgstr ""
+
+#: templates/membershipperson/edit.html:12
+msgid "member of"
 msgstr ""
 
 #: templates/membershipperson/search.html:7
@@ -987,7 +1188,7 @@ msgstr ""
 msgid "View/Edit Sources"
 msgstr ""
 
-#: templates/modals/source.html:9
+#: templates/modals/source.html:9 templates/partials/version_list.html:22
 msgid "Confidence"
 msgstr ""
 
@@ -1004,10 +1205,15 @@ msgid "High"
 msgstr ""
 
 #: templates/modals/source.html:21 templates/modals/source.html:24
+#: templates/modals/translate.html:20
 msgid "Add"
 msgstr ""
 
-#: templates/modals/source.html:28
+#: templates/modals/source.html:28 templates/modals/version.html:10
+#: templates/organization/detail.html:46 templates/organization/detail.html:64
+#: templates/partials/source_search_results.html:3
+#: templates/partials/version_list.html:25 templates/person/detail.html:28
+#: templates/person/detail.html:40
 msgid "Sources"
 msgstr ""
 
@@ -1015,12 +1221,182 @@ msgstr ""
 msgid "View/Edit Translations"
 msgstr ""
 
+#: templates/modals/translate.html:9
+msgid "Language"
+msgstr ""
+
+#: templates/modals/translate.html:10
+msgid "Translation"
+msgstr ""
+
+#: templates/modals/translate.html:14
+msgid "Add a Language:"
+msgstr ""
+
 #: templates/modals/version.html:4
 msgid "View/Revert Versions"
 msgstr ""
 
+#: templates/modals/version.html:9
+msgid "Versions"
+msgstr ""
+
+#: templates/modals/version.html:11
+msgid "Revert"
+msgstr ""
+
+#: templates/modals/version.html:15
+msgid "Choose Language"
+msgstr ""
+
+#: templates/organization/create-geography.html:14
+#: templates/partials/nav-wizard.html:9
+msgid "Geographies"
+msgstr ""
+
+#: templates/organization/create-geography.html:15
+msgid "Describe any geographies related to organizations found in"
+msgstr ""
+
+#: templates/organization/create-geography.html:51
+#: templates/organization/create-geography.html:174
+msgid "Geography type"
+msgstr ""
+
+#: templates/organization/create-geography.html:112
+#: templates/organization/create-geography.html:199
+msgid "Start & end dates"
+msgstr ""
+
+#: templates/organization/create-geography.html:137
+msgid "Add another geography"
+msgstr ""
+
+#: templates/organization/create-geography.html:191 violation/models.py:106
+msgid "OSM Name"
+msgstr ""
+
+#: templates/organization/create-geography.html:211
+msgid "Remove this geography"
+msgstr ""
+
+#: templates/organization/create.html:15
+msgid "Describe any units found in"
+msgstr ""
+
+#: templates/organization/create.html:33 templates/organization/create.html:163
+msgid "Unit name"
+msgstr ""
+
+#: templates/organization/create.html:54 templates/organization/create.html:172
+#: templates/organization/detail.html:104
+#: templates/organization/detail.html:155
+#: templates/organization/detail.html:206
+#: templates/organization/detail.html:257 templates/organization/edit.html:40
+#: templates/person/create.html:54 templates/person/create.html:154
+#: templates/person/edit.html:35
+msgid "Aliases"
+msgstr ""
+
+#: templates/organization/create.html:98 templates/organization/create.html:186
+#: templates/organization/edit.html:78 templates/person/create.html:70
+#: templates/person/create.html:161 templates/person/edit.html:54
+msgid "Division identifier"
+msgstr ""
+
+#: templates/organization/create.html:198
+msgid "Remove this unit"
+msgstr ""
+
+#: templates/organization/detail.html:20 templates/person/detail.html:14
+msgid "Also known as:"
+msgstr ""
+
+#: templates/organization/detail.html:38 templates/organization/detail.html:56
+#: templates/organization/detail.html:74
+msgid "Areas of operation"
+msgstr ""
+
+#: templates/organization/detail.html:39 templates/organization/detail.html:57
+#: templates/organization/detail.html:84
+msgid "Sites"
+msgstr ""
+
+#: templates/organization/detail.html:40 templates/organization/detail.html:58
+#: templates/organization/detail.html:96 templates/person/detail.html:25
+#: templates/person/detail.html:37 templates/person/detail.html:58
+#: templates/person/edit.html:72 templates/person/edit.html:78
+msgid "Memberships"
+msgstr ""
+
+#: templates/organization/detail.html:41 templates/organization/detail.html:59
+#: templates/organization/detail.html:149 templates/person/create.html:92
+#: templates/person/create.html:168
+msgid "Member units"
+msgstr ""
+
+#: templates/organization/detail.html:42 templates/organization/detail.html:60
+#: templates/organization/detail.html:200
+msgid "Parent units"
+msgstr ""
+
+#: templates/organization/detail.html:43 templates/organization/detail.html:61
+#: templates/organization/detail.html:251
+msgid "Subsidiaries"
+msgstr ""
+
+#: templates/organization/detail.html:44 templates/organization/detail.html:62
+#: templates/organization/detail.html:302
+msgid "Command personnel"
+msgstr ""
+
+#: templates/organization/detail.html:47 templates/organization/detail.html:65
+#: templates/partials/version_list.html:5 templates/person/detail.html:29
+#: templates/person/detail.html:41
+msgid "Changelog"
+msgstr ""
+
+#: templates/organization/detail.html:97
+msgid "Multi-unit organizations that this unit is part of."
+msgstr ""
+
+#: templates/organization/detail.html:105
+#: templates/organization/detail.html:156
+#: templates/organization/detail.html:207
+#: templates/organization/detail.html:258
+msgid "Classifications"
+msgstr ""
+
+#: templates/organization/detail.html:346
+msgid "Incident"
+msgstr ""
+
+#: templates/organization/detail.html:348
+msgid "in"
+msgstr ""
+
+#: templates/organization/detail.html:351
+msgid "between"
+msgstr ""
+
+#: templates/organization/detail.html:353
+msgid "starting"
+msgstr ""
+
+#: templates/organization/detail.html:355
+msgid "ending"
+msgstr ""
+
+#: templates/organization/edit.html:19
+msgid "Organization name"
+msgstr ""
+
 #: templates/organization/search.html:7
 msgid "Search an organization"
+msgstr ""
+
+#: templates/organization/search.html:9
+msgid "</"
 msgstr ""
 
 #: templates/organization/search.html:15 templates/person/search.html:15
@@ -1047,8 +1423,223 @@ msgstr ""
 msgid "Superior Unit"
 msgstr ""
 
-#: templates/person/edit.html:72 templates/person/edit.html:78
-msgid "Memberships"
+#: templates/partials/back_skip_next.html:7
+#: templates/partials/pagination.html:16
+msgid "Next"
+msgstr ""
+
+#: templates/partials/back_skip_next.html:7
+msgid "Finish"
+msgstr ""
+
+#: templates/partials/back_skip_next.html:10
+msgid "Go back"
+msgstr ""
+
+#: templates/partials/back_skip_next.html:12
+msgid "Skip"
+msgstr ""
+
+#: templates/partials/nav-wizard.html:5
+msgid "Create source"
+msgstr ""
+
+#: templates/partials/organization_list_table.html:34
+msgid "Last site name"
+msgstr ""
+
+#: templates/partials/organization_list_table.html:42
+msgid "Country"
+msgstr ""
+
+#: templates/partials/organization_merge.html:3
+msgid "Organizations"
+msgstr ""
+
+#: templates/partials/organization_search_results.html:6
+#: templates/partials/person_search_results.html:6
+#: templates/partials/violation_search_results.html:6
+msgid "results"
+msgstr ""
+
+#: templates/partials/organization_search_results.html:7
+#: templates/partials/person_search_results.html:7
+msgid "Merge selected"
+msgstr ""
+
+#: templates/partials/pagination.html:9
+msgid "Previous"
+msgstr ""
+
+#: templates/partials/person_list_table.html:7
+msgid "Select"
+msgstr ""
+
+#: templates/partials/person_list_table.html:10
+msgid "Select canonical record"
+msgstr ""
+
+#: templates/partials/person_list_table.html:20
+msgid "Also known as"
+msgstr ""
+
+#: templates/partials/person_list_table.html:21
+msgid "Most recent rank"
+msgstr ""
+
+#: templates/partials/person_list_table.html:22
+msgid "Most recent unit"
+msgstr ""
+
+#: templates/partials/person_list_table.html:23
+msgid "First citation"
+msgstr ""
+
+#: templates/partials/person_list_table.html:24
+msgid "Last citation"
+msgstr ""
+
+#: templates/partials/person_merge.html:3 templates/sidebar.html:8
+msgid "People"
+msgstr ""
+
+#: templates/partials/source_search_results.html:8
+msgid "Publication date"
+msgstr ""
+
+#: templates/partials/source_search_results.html:9
+msgid "Publication"
+msgstr ""
+
+#: templates/partials/source_search_results.html:10
+msgid "Publication country"
+msgstr ""
+
+#: templates/partials/version_list.html:7
+msgid ""
+"Select an attribute below to review the changes our staff have made to this "
+"entity."
+msgstr ""
+
+#: templates/partials/version_list.html:21
+msgid "Value"
+msgstr ""
+
+#: templates/partials/version_list.html:23
+msgid "Date created"
+msgstr ""
+
+#: templates/partials/version_list.html:24
+msgid "User"
+msgstr ""
+
+#: templates/partials/violation_description.html:7
+msgid "Show more"
+msgstr ""
+
+#: templates/partials/violation_description.html:8
+msgid "Show less"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:10
+msgid "Start Date"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:18
+msgid "End Date"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:25 violation/models.py:134
+msgid "Description"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:26
+msgid "Violation types"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:28 violation/models.py:127
+msgid "Location"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:35
+msgid "Perpetrators"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:37
+msgid "Perpetrator classification"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:67
+msgid "View Detail"
+msgstr ""
+
+#: templates/person/create.html:16
+msgid "Describe any personnel found in"
+msgstr ""
+
+#: templates/person/create.html:100
+msgid "A person must belong to at least one unit."
+msgstr ""
+
+#: templates/person/create.html:111
+msgid "Remove Person"
+msgstr ""
+
+#: templates/person/create.html:127
+msgid "Add another person"
+msgstr ""
+
+#: templates/person/create.html:183
+msgid "Remove this person"
+msgstr ""
+
+#: templates/person/detail.html:10
+msgid "Edit"
+msgstr ""
+
+#: templates/person/detail.html:24 templates/person/detail.html:36
+#: templates/person/detail.html:49
+msgid "Last seen as"
+msgstr ""
+
+#: templates/person/detail.html:26 templates/person/detail.html:38
+#: templates/person/detail.html:95
+msgid "Chain of command"
+msgstr ""
+
+#: templates/person/detail.html:27 templates/person/detail.html:39
+#: templates/person/detail.html:105
+msgid "Subordinates"
+msgstr ""
+
+#: templates/person/detail.html:106
+msgid ""
+"Commanders of units that were subordinate to any units commanded by this "
+"person"
+msgstr ""
+
+#: templates/person/detail.html:114
+msgid "Unit"
+msgstr ""
+
+#: templates/person/detail.html:115
+msgid "Start of overlap"
+msgstr ""
+
+#: templates/person/detail.html:116
+msgid "End of overlap"
+msgstr ""
+
+#: templates/person/detail.html:117
+msgid "Duration of overlap"
+msgstr ""
+
+#: templates/person/detail.html:149
+msgid "Events"
+msgstr ""
+
+#: templates/person/edit.html:14
+msgid "Person name"
 msgstr ""
 
 #: templates/person/search.html:32
@@ -1057,6 +1648,22 @@ msgstr ""
 
 #: templates/person/search.html:42 templates/person/search.html:130
 msgid "Death date"
+msgstr ""
+
+#: templates/sidebar.html:9
+msgid "Person Membership"
+msgstr ""
+
+#: templates/sidebar.html:16
+msgid "Violation"
+msgstr ""
+
+#: templates/sidebar.html:23
+msgid "Log Out"
+msgstr ""
+
+#: templates/sidebar.html:29
+msgid "Settings"
 msgstr ""
 
 #: templates/site/search.html:7
@@ -1111,18 +1718,6 @@ msgstr ""
 #: templates/violation/search.html:172 templates/violation/search.html:173
 #: violation/models.py:148
 msgid "Perpetrator Organization"
-msgstr ""
-
-#: violation/models.py:106
-msgid "OSM Name"
-msgstr ""
-
-#: violation/models.py:127
-msgid "Location"
-msgstr ""
-
-#: violation/models.py:134
-msgid "Description"
 msgstr ""
 
 #: violation/models.py:157

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -8,22 +8,33 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-15 18:19+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2017-08-24 15:24-0500\n"
+"PO-Revision-Date: 2017-08-24 18:51+0000\n"
+"Last-Translator: b'  <reginafcompton@datamade.us>'\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Translated-Using: django-rosetta 0.7.13\n"
 
 #: area/models.py:50 geosite/models.py:42 organization/models.py:43
 #: person/models.py:46 templates/area/search.html:24
-#: templates/area/search.html:84 templates/organization/search.html:22
-#: templates/organization/search.html:162 templates/person/search.html:21
-#: templates/person/search.html:128 templates/site/search.html:23
-#: templates/site/search.html:91
+#: templates/area/search.html:84
+#: templates/organization/create-geography.html:75
+#: templates/organization/create-geography.html:185
+#: templates/organization/detail.html:103
+#: templates/organization/detail.html:154
+#: templates/organization/detail.html:205
+#: templates/organization/detail.html:256
+#: templates/organization/detail.html:307 templates/organization/search.html:22
+#: templates/organization/search.html:162
+#: templates/partials/organization_list_table.html:10
+#: templates/partials/person_list_table.html:13 templates/person/create.html:34
+#: templates/person/create.html:146 templates/person/detail.html:111
+#: templates/person/search.html:21 templates/person/search.html:128
+#: templates/site/search.html:23 templates/site/search.html:91
 msgid "Name"
 msgstr "Nom"
 
@@ -34,7 +45,10 @@ msgstr ""
 #: area/models.py:67 composition/models.py:73 organization/models.py:69
 #: templates/area/search.html:28 templates/area/search.html:85
 #: templates/composition/search.html:97 templates/composition/search.html:140
-#: templates/organization/search.html:30 templates/organization/search.html:164
+#: templates/organization/create.html:76 templates/organization/create.html:179
+#: templates/organization/edit.html:59 templates/organization/search.html:30
+#: templates/organization/search.html:164
+#: templates/partials/organization_list_table.html:26
 msgid "Classification"
 msgstr "Classification"
 
@@ -42,7 +56,8 @@ msgstr "Classification"
 msgid "OSM name"
 msgstr ""
 
-#: area/models.py:86 geosite/models.py:85 violation/models.py:113
+#: area/models.py:86 geosite/models.py:85
+#: templates/organization/create-geography.html:90 violation/models.py:113
 msgid "OSM ID"
 msgstr ""
 
@@ -56,8 +71,10 @@ msgstr ""
 #: templates/composition/search.html:17 templates/composition/search.html:141
 #: templates/emplacement/search.html:23 templates/emplacement/search.html:138
 #: templates/membershipperson/search.html:139
-#: templates/organization/search.html:166 templates/violation/search.html:17
-#: templates/violation/search.html:194 violation/models.py:70
+#: templates/organization/detail.html:311
+#: templates/organization/search.html:166 templates/person/detail.html:67
+#: templates/violation/search.html:17 templates/violation/search.html:194
+#: violation/models.py:70
 msgid "Start date"
 msgstr ""
 
@@ -66,21 +83,27 @@ msgstr ""
 #: templates/composition/search.html:56 templates/composition/search.html:142
 #: templates/emplacement/search.html:62 templates/emplacement/search.html:139
 #: templates/membershipperson/search.html:140
-#: templates/organization/search.html:167 templates/violation/search.html:56
-#: templates/violation/search.html:195 violation/models.py:77
+#: templates/organization/detail.html:312
+#: templates/organization/search.html:167 templates/person/detail.html:68
+#: templates/violation/search.html:56 templates/violation/search.html:195
+#: violation/models.py:77
 msgid "End date"
 msgstr ""
 
 #: association/models.py:59 emplacement/models.py:64
-#: membershiporganization/models.py:65 membershipperson/models.py:72
+#: membershiporganization/models.py:65 membershipperson/models.py:136
 #: templates/association/search.html:109 templates/association/search.html:140
 #: templates/emplacement/search.html:109 templates/emplacement/search.html:140
-#: templates/organization/edit.html:10 templates/violation/search.html:198
+#: templates/membershiporganization/create.html:44
+#: templates/organization/create-geography.html:32
+#: templates/organization/create-geography.html:164
+#: templates/organization/edit.html:10 templates/person/detail.html:63
+#: templates/sidebar.html:10 templates/violation/search.html:198
 msgid "Organization"
-msgstr ""
+msgstr "Organisation"
 
 #: association/models.py:70 templates/association/search.html:117
-#: templates/association/search.html:141
+#: templates/association/search.html:141 templates/sidebar.html:13
 msgid "Area"
 msgstr ""
 
@@ -97,7 +120,8 @@ msgid "Child organization"
 msgstr ""
 
 #: emplacement/models.py:72 templates/emplacement/search.html:117
-#: templates/emplacement/search.html:141 templates/site/edit.html:8
+#: templates/emplacement/search.html:141 templates/sidebar.html:15
+#: templates/site/edit.html:8
 msgid "Site"
 msgstr ""
 
@@ -117,56 +141,73 @@ msgstr ""
 msgid "Coordinates"
 msgstr ""
 
-#: geosite/models.py:101
+#: geosite/models.py:101 templates/organization/detail.html:106
+#: templates/organization/detail.html:157
+#: templates/organization/detail.html:208
+#: templates/organization/detail.html:259
 msgid "First cited"
 msgstr ""
 
-#: geosite/models.py:109
+#: geosite/models.py:109 templates/organization/detail.html:107
+#: templates/organization/detail.html:158
+#: templates/organization/detail.html:209
+#: templates/organization/detail.html:260
 msgid "Last cited"
 msgstr ""
 
-#: membershiporganization/models.py:54 membershipperson/models.py:64
+#: membershiporganization/models.py:54 membershipperson/models.py:128
 msgid "Member"
 msgstr ""
 
-#: membershiporganization/models.py:76 membershipperson/models.py:105
+#: membershiporganization/models.py:76 membershipperson/models.py:169
 #: templates/membershipperson/search.html:42
 msgid "First cited date"
 msgstr ""
 
-#: membershiporganization/models.py:87 membershipperson/models.py:113
+#: membershiporganization/models.py:87 membershipperson/models.py:177
 #: templates/membershipperson/search.html:81
 msgid "Last cited date"
 msgstr ""
 
-#: membershipperson/models.py:80 templates/membershipperson/search.html:17
-#: templates/membershipperson/search.html:136 templates/person/edit.html:80
+#: membershipperson/models.py:144 templates/membershipperson/search.html:17
+#: templates/membershipperson/search.html:136
+#: templates/organization/detail.html:309 templates/person/detail.html:65
+#: templates/person/detail.html:113 templates/person/edit.html:80
 msgid "Role"
 msgstr ""
 
-#: membershipperson/models.py:89 templates/membershipperson/search.html:35
-#: templates/membershipperson/search.html:137 templates/person/edit.html:79
+#: membershipperson/models.py:153 templates/membershipperson/create.html:40
+#: templates/membershipperson/edit.html:21
+#: templates/membershipperson/search.html:35
+#: templates/membershipperson/search.html:137
+#: templates/organization/detail.html:310
+#: templates/partials/source_search_results.html:7
+#: templates/person/detail.html:66 templates/person/edit.html:79
 msgid "Title"
 msgstr ""
 
-#: membershipperson/models.py:97 templates/membershipperson/search.html:26
-#: templates/membershipperson/search.html:138 templates/person/edit.html:81
+#: membershipperson/models.py:161 templates/membershipperson/search.html:26
+#: templates/membershipperson/search.html:138
+#: templates/organization/detail.html:308 templates/person/detail.html:64
+#: templates/person/detail.html:112 templates/person/edit.html:81
 msgid "Rank"
 msgstr ""
 
-#: membershipperson/models.py:121
+#: membershipperson/models.py:185
 msgid "Real start date"
 msgstr ""
 
-#: membershipperson/models.py:129
+#: membershipperson/models.py:193
 msgid "Real end date"
 msgstr ""
 
-#: membershipperson/models.py:137
+#: membershipperson/models.py:201 templates/membershipperson/create.html:90
+#: templates/membershipperson/edit.html:77
 msgid "Start context"
 msgstr ""
 
-#: membershipperson/models.py:145
+#: membershipperson/models.py:209 templates/membershipperson/create.html:119
+#: templates/membershipperson/edit.html:106
 msgid "End context"
 msgstr ""
 
@@ -201,7 +242,7 @@ msgstr ""
 msgid "Alias"
 msgstr "Alias"
 
-#: person/views.py:351 templates/person/search.html:7
+#: person/views.py:398 templates/person/search.html:7
 msgid "Person"
 msgstr "Personne"
 
@@ -209,19 +250,19 @@ msgstr "Personne"
 msgid "Please add a source for this information"
 msgstr ""
 
-#: sfm_pc/settings.py:148 tests/test_settings.py:127
+#: sfm_pc/settings.py:149 tests/test_settings.py:127
 msgid "French"
 msgstr "Français"
 
-#: sfm_pc/settings.py:149 tests/test_settings.py:128
+#: sfm_pc/settings.py:150 tests/test_settings.py:128
 msgid "English"
 msgstr "Anglais"
 
-#: sfm_pc/settings.py:150 tests/test_settings.py:129
+#: sfm_pc/settings.py:151 tests/test_settings.py:129
 msgid "Spanish"
 msgstr ""
 
-#: sfm_pc/utils.py:349
+#: sfm_pc/utils.py:500
 msgid "Object sources"
 msgstr ""
 
@@ -399,6 +440,7 @@ msgid "E-mail address"
 msgstr ""
 
 #: templates/account/login.html:17 templates/account/login.html:18
+#: templates/login.html:28
 msgid "Password"
 msgstr ""
 
@@ -594,19 +636,43 @@ msgstr ""
 msgid "Area of Operations"
 msgstr ""
 
+#: templates/area/edit.html:13 templates/composition/edit.html:11
+#: templates/composition/search.html:9
+msgid "Add new"
+msgstr ""
+
+#: templates/area/edit.html:19 templates/area/search.html:17
+#: templates/association/edit.html:17 templates/association/search.html:16
+#: templates/composition/edit.html:19 templates/emplacement/edit.html:17
+#: templates/emplacement/search.html:16 templates/site/search.html:16
+msgid "Properties"
+msgstr ""
+
+#: templates/area/edit.html:47 templates/association/edit.html:46
+#: templates/composition/edit.html:57 templates/delete_confirm.html:18
+#: templates/emplacement/edit.html:46 templates/site/edit.html:53
+#: templates/violation/edit.html:170
+msgid "Cancel"
+msgstr ""
+
+#: templates/area/edit.html:48 templates/association/edit.html:47
+#: templates/composition/edit.html:58 templates/emplacement/edit.html:47
+#: templates/partials/organization_merge.html:9
+#: templates/partials/person_merge.html:9 templates/site/edit.html:54
+#: templates/violation/edit.html:171
+msgid "Save"
+msgstr ""
+
 #: templates/area/search.html:8
 msgid "Search Area"
 msgstr ""
 
-#: templates/area/search.html:10 templates/association/search.html:9
-#: templates/emplacement/search.html:9 templates/person/search.html:9
+#: templates/area/search.html:10 templates/association/edit.html:11
+#: templates/association/search.html:9 templates/emplacement/edit.html:11
+#: templates/emplacement/search.html:9 templates/membershipperson/search.html:9
+#: templates/organization/search.html:9 templates/person/search.html:9
 #: templates/site/search.html:9
 msgid "Add New"
-msgstr ""
-
-#: templates/area/search.html:17 templates/association/search.html:16
-#: templates/emplacement/search.html:16 templates/site/search.html:16
-msgid "Properties"
 msgstr ""
 
 #: templates/area/search.html:25 templates/organization/search.html:23
@@ -689,19 +755,21 @@ msgstr ""
 
 #: templates/area/search.html:71 templates/association/search.html:125
 #: templates/composition/search.html:125 templates/emplacement/search.html:125
-#: templates/membershipperson/search.html:123 templates/person/search.html:115
+#: templates/membershipperson/search.html:123
+#: templates/organization/search.html:149 templates/person/search.html:115
 #: templates/site/search.html:78 templates/violation/search.html:181
 msgid "Results"
 msgstr ""
 
 #: templates/area/search.html:73 templates/association/search.html:127
 #: templates/composition/search.html:127 templates/emplacement/search.html:127
-#: templates/membershipperson/search.html:125 templates/person/search.html:117
+#: templates/membershipperson/search.html:125
+#: templates/organization/search.html:151 templates/person/search.html:117
 #: templates/site/search.html:80 templates/violation/search.html:183
 msgid "Export"
 msgstr ""
 
-#: templates/association/edit.html:9
+#: templates/association/edit.html:9 templates/sidebar.html:12
 msgid "Association"
 msgstr ""
 
@@ -709,18 +777,6 @@ msgstr ""
 #: templates/composition/edit.html:47 templates/composition/search.html:114
 #: templates/emplacement/edit.html:36 templates/emplacement/search.html:114
 msgid "With"
-msgstr ""
-
-#: templates/association/edit.html:46 templates/composition/edit.html:57
-#: templates/emplacement/edit.html:46 templates/site/edit.html:53
-#: templates/violation/edit.html:170
-msgid "Cancel"
-msgstr ""
-
-#: templates/association/edit.html:47 templates/composition/edit.html:58
-#: templates/emplacement/edit.html:47 templates/site/edit.html:54
-#: templates/violation/edit.html:171
-msgid "Save"
 msgstr ""
 
 #: templates/association/search.html:7
@@ -909,7 +965,8 @@ msgstr ""
 msgid "yyyy"
 msgstr ""
 
-#: templates/association/search.html:103 templates/emplacement/search.html:103
+#: templates/association/search.html:103 templates/composition/edit.html:37
+#: templates/emplacement/search.html:103
 msgid "Relations"
 msgstr ""
 
@@ -917,16 +974,92 @@ msgstr ""
 msgid "Enter organization name"
 msgstr ""
 
-#: templates/base_modal.html:8 templates/modals/source.html:34
+#: templates/base.html:27
+msgid "A tool from"
+msgstr ""
+
+#: templates/base.html:44
+msgid "Countries"
+msgstr ""
+
+#: templates/base.html:45 templates/partials/nav-wizard.html:7
+#: templates/partials/person_search_results.html:5
+#: templates/person/create.html:15
+#, fuzzy
+#| msgid "Person"
+msgid "Personnel"
+msgstr "Personne"
+
+#: templates/base.html:46 templates/organization/create.html:14
+#: templates/partials/nav-wizard.html:6
+#: templates/partials/organization_search_results.html:5
+msgid "Units"
+msgstr ""
+
+#: templates/base.html:47 templates/organization/detail.html:45
+#: templates/organization/detail.html:63 templates/organization/detail.html:339
+#: templates/partials/nav-wizard.html:10
+#: templates/partials/violation_search_results.html:5
+msgid "Incidents"
+msgstr ""
+
+#: templates/base.html:48
+msgid "Help"
+msgstr ""
+
+#: templates/base.html:52
+msgid "New source"
+msgstr ""
+
+#: templates/base.html:56
+msgid "Logout"
+msgstr ""
+
+#: templates/base_detail.html:19 templates/base_detail.html:29
+msgid "Contents"
+msgstr ""
+
+#: templates/base_modal.html:10 templates/modals/source.html:34
+#: templates/modals/translate.html:24 templates/modals/version.html:26
 msgid "Close"
 msgstr ""
 
-#: templates/composition/edit.html:9
-msgid "Composition"
+#: templates/composition/create.html:13
+msgid "Unit relationships"
 msgstr ""
 
-#: templates/composition/edit.html:11 templates/composition/search.html:9
-msgid "Add new"
+#: templates/composition/create.html:15
+msgid "Describe how units are related to one another in"
+msgstr ""
+
+#: templates/composition/create.html:27
+msgid "Relationships for"
+msgstr ""
+
+#: templates/composition/create.html:29
+#, fuzzy
+#| msgid "Remove this person"
+msgid "Remove this relationship"
+msgstr "Retirer cette personne "
+
+#: templates/composition/create.html:38
+msgid "Relationship type"
+msgstr ""
+
+#: templates/composition/create.html:61
+#, fuzzy
+#| msgid "Organization"
+msgid "Related organization"
+msgstr "Organisation"
+
+#: templates/composition/create.html:87
+#, fuzzy
+#| msgid "Classification"
+msgid "Relationship classification"
+msgstr "Classification"
+
+#: templates/composition/edit.html:9 templates/sidebar.html:11
+msgid "Composition"
 msgstr ""
 
 #: templates/composition/search.html:7
@@ -946,6 +1079,7 @@ msgid "Enter child organization"
 msgstr ""
 
 #: templates/composition/search.html:138
+#: templates/partials/organization_list_table.html:18
 msgid "Parent"
 msgstr ""
 
@@ -961,12 +1095,92 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: templates/emplacement/edit.html:9
+#: templates/emplacement/edit.html:9 templates/sidebar.html:14
 msgid "Emplacement"
 msgstr ""
 
 #: templates/emplacement/search.html:7
 msgid "Search Emplacement"
+msgstr ""
+
+#: templates/login.html:26
+#, fuzzy
+#| msgid "E-mail Addresses"
+msgid "Email address"
+msgstr "Adresse courriel"
+
+#: templates/login.html:31
+msgid "Forgot Password?"
+msgstr ""
+
+#: templates/login.html:33
+msgid "Sign in"
+msgstr ""
+
+#: templates/membershiporganization/create.html:17
+msgid "Unit memberships"
+msgstr ""
+
+#: templates/membershiporganization/create.html:19
+msgid "Describe which organizations (if any) are members of one another in"
+msgstr ""
+
+#: templates/membershiporganization/create.html:33
+msgid "Memberships for"
+msgstr ""
+
+#: templates/membershiporganization/create.html:35
+#, fuzzy
+#| msgid "Remove this person"
+msgid "Remove this membership"
+msgstr "Retirer cette personne "
+
+#: templates/membershiporganization/create.html:69
+msgid "First & last citation dates"
+msgstr ""
+
+#: templates/membershipperson/create.html:15
+#: templates/partials/nav-wizard.html:8
+msgid "Positions"
+msgstr ""
+
+#: templates/membershipperson/create.html:16
+msgid "Describe positions held by personnel in"
+msgstr ""
+
+#: templates/membershipperson/create.html:55
+#: templates/membershipperson/edit.html:36
+msgid "Role & Rank"
+msgstr ""
+
+#: templates/membershipperson/create.html:58
+#: templates/membershipperson/edit.html:39
+msgid "Select a Role"
+msgstr ""
+
+#: templates/membershipperson/create.html:72
+#: templates/membershipperson/edit.html:56
+msgid "Select a Rank"
+msgstr ""
+
+#: templates/membershipperson/create.html:102
+#: templates/membershipperson/create.html:104
+#: templates/membershipperson/create.html:131
+#: templates/membershipperson/create.html:133
+#: templates/membershipperson/edit.html:89
+#: templates/membershipperson/edit.html:91
+#: templates/membershipperson/edit.html:118
+#: templates/membershipperson/edit.html:120
+msgid "Real context?"
+msgstr ""
+
+#: templates/membershipperson/create.html:148
+#: templates/membershipperson/edit.html:135
+msgid "Citation dates"
+msgstr ""
+
+#: templates/membershipperson/edit.html:12
+msgid "member of"
 msgstr ""
 
 #: templates/membershipperson/search.html:7
@@ -989,7 +1203,7 @@ msgstr ""
 msgid "View/Edit Sources"
 msgstr ""
 
-#: templates/modals/source.html:9
+#: templates/modals/source.html:9 templates/partials/version_list.html:22
 msgid "Confidence"
 msgstr ""
 
@@ -1006,10 +1220,15 @@ msgid "High"
 msgstr "Haute"
 
 #: templates/modals/source.html:21 templates/modals/source.html:24
+#: templates/modals/translate.html:20
 msgid "Add"
 msgstr ""
 
-#: templates/modals/source.html:28
+#: templates/modals/source.html:28 templates/modals/version.html:10
+#: templates/organization/detail.html:46 templates/organization/detail.html:64
+#: templates/partials/source_search_results.html:3
+#: templates/partials/version_list.html:25 templates/person/detail.html:28
+#: templates/person/detail.html:40
 msgid "Sources"
 msgstr ""
 
@@ -1017,12 +1236,202 @@ msgstr ""
 msgid "View/Edit Translations"
 msgstr ""
 
+#: templates/modals/translate.html:9
+msgid "Language"
+msgstr ""
+
+#: templates/modals/translate.html:10
+#, fuzzy
+#| msgid "Organization"
+msgid "Translation"
+msgstr "Organisation"
+
+#: templates/modals/translate.html:14
+msgid "Add a Language:"
+msgstr ""
+
 #: templates/modals/version.html:4
 msgid "View/Revert Versions"
 msgstr ""
 
+#: templates/modals/version.html:9
+msgid "Versions"
+msgstr ""
+
+#: templates/modals/version.html:11
+msgid "Revert"
+msgstr ""
+
+#: templates/modals/version.html:15
+msgid "Choose Language"
+msgstr ""
+
+#: templates/organization/create-geography.html:14
+#: templates/partials/nav-wizard.html:9
+msgid "Geographies"
+msgstr ""
+
+#: templates/organization/create-geography.html:15
+msgid "Describe any geographies related to organizations found in"
+msgstr ""
+
+#: templates/organization/create-geography.html:51
+#: templates/organization/create-geography.html:174
+msgid "Geography type"
+msgstr ""
+
+#: templates/organization/create-geography.html:112
+#: templates/organization/create-geography.html:199
+msgid "Start & end dates"
+msgstr ""
+
+#: templates/organization/create-geography.html:137
+msgid "Add another geography"
+msgstr ""
+
+#: templates/organization/create-geography.html:191 violation/models.py:106
+#, fuzzy
+#| msgid "Name"
+msgid "OSM Name"
+msgstr "Nom"
+
+#: templates/organization/create-geography.html:211
+#, fuzzy
+#| msgid "Remove this person"
+msgid "Remove this geography"
+msgstr "Retirer cette personne "
+
+#: templates/organization/create.html:15
+msgid "Describe any units found in"
+msgstr ""
+
+#: templates/organization/create.html:33 templates/organization/create.html:163
+#, fuzzy
+#| msgid "Person"
+msgid "Unit name"
+msgstr "Personne"
+
+#: templates/organization/create.html:54 templates/organization/create.html:172
+#: templates/organization/detail.html:104
+#: templates/organization/detail.html:155
+#: templates/organization/detail.html:206
+#: templates/organization/detail.html:257 templates/organization/edit.html:40
+#: templates/person/create.html:54 templates/person/create.html:154
+#: templates/person/edit.html:35
+#, fuzzy
+#| msgid "Aliases"
+msgid "Aliases"
+msgstr "Alias"
+
+#: templates/organization/create.html:98 templates/organization/create.html:186
+#: templates/organization/edit.html:78 templates/person/create.html:70
+#: templates/person/create.html:161 templates/person/edit.html:54
+msgid "Division identifier"
+msgstr ""
+
+#: templates/organization/create.html:198
+#, fuzzy
+#| msgid "Remove this person"
+msgid "Remove this unit"
+msgstr "Retirer cette personne "
+
+#: templates/organization/detail.html:20 templates/person/detail.html:14
+#, fuzzy
+#| msgid "Also known as"
+msgid "Also known as:"
+msgstr "Alias"
+
+#: templates/organization/detail.html:38 templates/organization/detail.html:56
+#: templates/organization/detail.html:74
+msgid "Areas of operation"
+msgstr ""
+
+#: templates/organization/detail.html:39 templates/organization/detail.html:57
+#: templates/organization/detail.html:84
+msgid "Sites"
+msgstr ""
+
+#: templates/organization/detail.html:40 templates/organization/detail.html:58
+#: templates/organization/detail.html:96 templates/person/detail.html:25
+#: templates/person/detail.html:37 templates/person/detail.html:58
+#: templates/person/edit.html:72 templates/person/edit.html:78
+msgid "Memberships"
+msgstr ""
+
+#: templates/organization/detail.html:41 templates/organization/detail.html:59
+#: templates/organization/detail.html:149 templates/person/create.html:92
+#: templates/person/create.html:168
+msgid "Member units"
+msgstr ""
+
+#: templates/organization/detail.html:42 templates/organization/detail.html:60
+#: templates/organization/detail.html:200
+msgid "Parent units"
+msgstr ""
+
+#: templates/organization/detail.html:43 templates/organization/detail.html:61
+#: templates/organization/detail.html:251
+msgid "Subsidiaries"
+msgstr ""
+
+#: templates/organization/detail.html:44 templates/organization/detail.html:62
+#: templates/organization/detail.html:302
+#, fuzzy
+#| msgid "Person"
+msgid "Command personnel"
+msgstr "Personne"
+
+#: templates/organization/detail.html:47 templates/organization/detail.html:65
+#: templates/partials/version_list.html:5 templates/person/detail.html:29
+#: templates/person/detail.html:41
+msgid "Changelog"
+msgstr ""
+
+#: templates/organization/detail.html:97
+msgid "Multi-unit organizations that this unit is part of."
+msgstr ""
+
+#: templates/organization/detail.html:105
+#: templates/organization/detail.html:156
+#: templates/organization/detail.html:207
+#: templates/organization/detail.html:258
+#, fuzzy
+#| msgid "Classification"
+msgid "Classifications"
+msgstr "Classification"
+
+#: templates/organization/detail.html:346
+msgid "Incident"
+msgstr ""
+
+#: templates/organization/detail.html:348
+msgid "in"
+msgstr ""
+
+#: templates/organization/detail.html:351
+msgid "between"
+msgstr ""
+
+#: templates/organization/detail.html:353
+msgid "starting"
+msgstr ""
+
+#: templates/organization/detail.html:355
+msgid "ending"
+msgstr ""
+
+#: templates/organization/edit.html:19
+#, fuzzy
+#| msgid "Organization"
+msgid "Organization name"
+msgstr "Organisation"
+
 #: templates/organization/search.html:7
 msgid "Search an organization"
+msgstr ""
+
+#: templates/organization/search.html:9
+msgid "</"
 msgstr ""
 
 #: templates/organization/search.html:15 templates/person/search.html:15
@@ -1049,9 +1458,234 @@ msgstr ""
 msgid "Superior Unit"
 msgstr ""
 
-#: templates/person/edit.html:72 templates/person/edit.html:78
-msgid "Memberships"
+#: templates/partials/back_skip_next.html:7
+#: templates/partials/pagination.html:16
+msgid "Next"
 msgstr ""
+
+#: templates/partials/back_skip_next.html:7
+msgid "Finish"
+msgstr ""
+
+#: templates/partials/back_skip_next.html:10
+msgid "Go back"
+msgstr ""
+
+#: templates/partials/back_skip_next.html:12
+msgid "Skip"
+msgstr ""
+
+#: templates/partials/nav-wizard.html:5
+msgid "Create source"
+msgstr ""
+
+#: templates/partials/organization_list_table.html:34
+msgid "Last site name"
+msgstr ""
+
+#: templates/partials/organization_list_table.html:42
+msgid "Country"
+msgstr ""
+
+#: templates/partials/organization_merge.html:3
+#, fuzzy
+#| msgid "Organization"
+msgid "Organizations"
+msgstr "Organisation"
+
+#: templates/partials/organization_search_results.html:6
+#: templates/partials/person_search_results.html:6
+#: templates/partials/violation_search_results.html:6
+msgid "results"
+msgstr ""
+
+#: templates/partials/organization_search_results.html:7
+#: templates/partials/person_search_results.html:7
+msgid "Merge selected"
+msgstr ""
+
+#: templates/partials/pagination.html:9
+msgid "Previous"
+msgstr ""
+
+#: templates/partials/person_list_table.html:7
+msgid "Select"
+msgstr ""
+
+#: templates/partials/person_list_table.html:10
+msgid "Select canonical record"
+msgstr ""
+
+#: templates/partials/person_list_table.html:20
+msgid "Also known as"
+msgstr "Alias"
+
+#: templates/partials/person_list_table.html:21
+msgid "Most recent rank"
+msgstr ""
+
+#: templates/partials/person_list_table.html:22
+msgid "Most recent unit"
+msgstr ""
+
+#: templates/partials/person_list_table.html:23
+msgid "First citation"
+msgstr ""
+
+#: templates/partials/person_list_table.html:24
+msgid "Last citation"
+msgstr ""
+
+#: templates/partials/person_merge.html:3 templates/sidebar.html:8
+msgid "People"
+msgstr ""
+
+#: templates/partials/source_search_results.html:8
+msgid "Publication date"
+msgstr ""
+
+#: templates/partials/source_search_results.html:9
+#, fuzzy
+#| msgid "Classification"
+msgid "Publication"
+msgstr "Classification"
+
+#: templates/partials/source_search_results.html:10
+msgid "Publication country"
+msgstr ""
+
+#: templates/partials/version_list.html:7
+msgid ""
+"Select an attribute below to review the changes our staff have made to this "
+"entity."
+msgstr ""
+
+#: templates/partials/version_list.html:21
+msgid "Value"
+msgstr ""
+
+#: templates/partials/version_list.html:23
+msgid "Date created"
+msgstr ""
+
+#: templates/partials/version_list.html:24
+msgid "User"
+msgstr ""
+
+#: templates/partials/violation_description.html:7
+msgid "Show more"
+msgstr ""
+
+#: templates/partials/violation_description.html:8
+msgid "Show less"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:10
+msgid "Start Date"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:18
+msgid "End Date"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:25 violation/models.py:134
+msgid "Description"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:26
+msgid "Violation types"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:28 violation/models.py:127
+msgid "Location"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:35
+msgid "Perpetrators"
+msgstr ""
+
+#: templates/partials/violation_list_table.html:37
+#, fuzzy
+#| msgid "Classification"
+msgid "Perpetrator classification"
+msgstr "Classification"
+
+#: templates/partials/violation_list_table.html:67
+msgid "View Detail"
+msgstr ""
+
+#: templates/person/create.html:16
+msgid "Describe any personnel found in"
+msgstr ""
+
+#: templates/person/create.html:100
+msgid "A person must belong to at least one unit."
+msgstr ""
+
+#: templates/person/create.html:111
+#, fuzzy
+#| msgid "Person"
+msgid "Remove Person"
+msgstr "Personne"
+
+#: templates/person/create.html:127
+msgid "Add another person"
+msgstr ""
+
+#: templates/person/create.html:183
+msgid "Remove this person"
+msgstr "Retirer cette personne "
+
+#: templates/person/detail.html:10
+msgid "Edit"
+msgstr ""
+
+#: templates/person/detail.html:24 templates/person/detail.html:36
+#: templates/person/detail.html:49
+msgid "Last seen as"
+msgstr ""
+
+#: templates/person/detail.html:26 templates/person/detail.html:38
+#: templates/person/detail.html:95
+msgid "Chain of command"
+msgstr ""
+
+#: templates/person/detail.html:27 templates/person/detail.html:39
+#: templates/person/detail.html:105
+msgid "Subordinates"
+msgstr ""
+
+#: templates/person/detail.html:106
+msgid ""
+"Commanders of units that were subordinate to any units commanded by this "
+"person"
+msgstr ""
+
+#: templates/person/detail.html:114
+msgid "Unit"
+msgstr ""
+
+#: templates/person/detail.html:115
+msgid "Start of overlap"
+msgstr ""
+
+#: templates/person/detail.html:116
+msgid "End of overlap"
+msgstr ""
+
+#: templates/person/detail.html:117
+msgid "Duration of overlap"
+msgstr ""
+
+#: templates/person/detail.html:149
+msgid "Events"
+msgstr ""
+
+#: templates/person/edit.html:14
+#, fuzzy
+#| msgid "Person"
+msgid "Person name"
+msgstr "Personne"
 
 #: templates/person/search.html:32
 msgid "Membership"
@@ -1059,6 +1693,24 @@ msgstr ""
 
 #: templates/person/search.html:42 templates/person/search.html:130
 msgid "Death date"
+msgstr ""
+
+#: templates/sidebar.html:9
+#, fuzzy
+#| msgid "Person"
+msgid "Person Membership"
+msgstr "Personne"
+
+#: templates/sidebar.html:16
+msgid "Violation"
+msgstr ""
+
+#: templates/sidebar.html:23
+msgid "Log Out"
+msgstr ""
+
+#: templates/sidebar.html:29
+msgid "Settings"
 msgstr ""
 
 #: templates/site/search.html:7
@@ -1115,20 +1767,6 @@ msgstr ""
 #: templates/violation/search.html:172 templates/violation/search.html:173
 #: violation/models.py:148
 msgid "Perpetrator Organization"
-msgstr ""
-
-#: violation/models.py:106
-#, fuzzy
-#| msgid "Name"
-msgid "OSM Name"
-msgstr "Nom"
-
-#: violation/models.py:127
-msgid "Location"
-msgstr ""
-
-#: violation/models.py:134
-msgid "Description"
 msgstr ""
 
 #: violation/models.py:157

--- a/sfm_pc/settings.py
+++ b/sfm_pc/settings.py
@@ -155,6 +155,7 @@ LOCALE_PATHS = (
 )
 
 LANGUAGE_CODE = 'en'
+# LANGUAGE_CODE = 'fr'
 
 
 TIME_ZONE = 'UTC'

--- a/templates/area/edit.html
+++ b/templates/area/edit.html
@@ -10,13 +10,13 @@
     <div class="inner-title-wrapper">
       <h1 class="page-title">{% trans "Area of Operations" %}</h1>
       <div class="pull-right">
-        <a href="/area/add/" class="btn sfm-btn-action"><i class="fa fa-plus"></i> Add new</a>
+        <a href="/area/add/" class="btn sfm-btn-action"><i class="fa fa-plus"></i> {% trans "Add new" %}</a>
       </div>
     </div>
   </div>
   <div class="row">
     <div class="col-sm-12">
-      <h3>Properties</h3>
+      <h3>{% trans "Properties" %}</h3>
     </div>
   </div>
 
@@ -44,8 +44,8 @@
 
   <div class="row">
     <div class="col-sm-12 col-md-12">
-      <button class="btn sfm-btn-cancel col-sm-2" type="submit">Cancel</button>
-      <button class="btn col-sm-2 pull-right sfm-btn-action addObject" type="submit">Save</button>
+      <button class="btn sfm-btn-cancel col-sm-2" type="submit">{% trans "Cancel" %}</button>
+      <button class="btn col-sm-2 pull-right sfm-btn-action addObject" type="submit">{% trans "Save" %}</button>
     </div>
   </div>
 

--- a/templates/association/edit.html
+++ b/templates/association/edit.html
@@ -8,13 +8,13 @@
     <div class="inner-title-wrapper">
       <h1 class="page-title">{% trans "Association" %}</h1>
       <div class="pull-right">
-        <a href="/association/add/" class="btn sfm-btn-action"><i class="fa fa-plus"> Add New</i></a>
+        <a href="/association/add/" class="btn sfm-btn-action"><i class="fa fa-plus"> {% trans "Add New" %}</i></a>
       </div>
     </div>
   </div>
   <div class="row">
     <div class="col-sm-12">
-      <h4>Properties</h4>
+      <h4>{% trans "Properties" %}</h4>
     </div>
   </div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,7 +24,7 @@
   </script>
 
 <div class="pre-navbar">
-  <p>A tool from <a href="https://securityforcemonitor.org">Security Force Monitor</a></p>
+  <p>{% trans "A tool from" %} <a href="https://securityforcemonitor.org">Security Force Monitor</a></p>
 </div>
 <nav class="navbar navbar-default">
     <div class="container-fluid">
@@ -41,19 +41,19 @@
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
-                <li class="{{ countries_tab }}"><a href="{% url 'countries' %}"><i class="fa fa-fw fa-globe"></i> Countries</a></li>
-                <li class="{{ person_tab }}"><a href="{% url 'search' %}?entity_type=Person"><i class="fa fa-fw fa-user"></i> Personnel</a></li>
-                <li class="{{ organization_tab }}"><a href="{% url 'search' %}?entity_type=Organization"><i class="fa fa-fw fa-users"></i> Units</a></li>
-                <li class="{{ violation_tab }}"><a href="{% url 'search' %}?entity_type=Violation"><i class="fa fa-fw fa-exclamation-triangle"></i> Incidents</a></li>
-                <li class="{{ help_tab }}"><a href="#"><i class="fa fa-fw fa-question-circle"></i> Help</a></li>
+                <li class="{{ countries_tab }}"><a href="{% url 'countries' %}"><i class="fa fa-fw fa-globe"></i> {% trans "Countries" %}</a></li>
+                <li class="{{ person_tab }}"><a href="{% url 'search' %}?entity_type=Person"><i class="fa fa-fw fa-user"></i> {% trans "Personnel" %}</a></li>
+                <li class="{{ organization_tab }}"><a href="{% url 'search' %}?entity_type=Organization"><i class="fa fa-fw fa-users"></i> {% trans "Units" %}</a></li>
+                <li class="{{ violation_tab }}"><a href="{% url 'search' %}?entity_type=Violation"><i class="fa fa-fw fa-exclamation-triangle"></i> {% trans "Incidents" %}</a></li>
+                <li class="{{ help_tab }}"><a href="#"><i class="fa fa-fw fa-question-circle"></i> {% trans "Help" %}</a></li>
                 {% if user.is_staff %}
                 <li class="{{ new_source_tab }}">
                     <a href="{% url 'create-source' %}">
-                        <i class="fa fa-fw fa-plus"></i> New source
+                        <i class="fa fa-fw fa-plus"></i> {% trans "New source" %}
                     </a>
                 </li>
                 {% endif %}
-                {% if user.is_authenticated %}<li><a href="{% url 'logout' %}"><i class="fa fa-fw fa-arrow-right"></i> Logout</a></li>{% endif %}
+                {% if user.is_authenticated %}<li><a href="{% url 'logout' %}"><i class="fa fa-fw fa-arrow-right"></i> {% trans "Logout" %}</a></li>{% endif %}
             </ul>
         </div>
     </div>

--- a/templates/base_detail.html
+++ b/templates/base_detail.html
@@ -16,7 +16,7 @@
     <!-- On desktop, show a fixed scrollspy sidebar -->
     <div class="col-md-3 hidden-xs hidden-sm">
         <div id="sidebar">
-            <h3>Contents</h3>
+            <h3>{% trans "Contents" %}</h3>
             <ul class="nav nav-pills nav-stacked">
                 {% block sidebar %}{% endblock %}
             </ul>
@@ -26,7 +26,7 @@
     <div class="col-xs-12 col-md-9">
         <!-- On mobile, show a table of contents near the top of the page -->
         <div class="visible-xs visible-sm" id="table-of-contents">
-            <h3>Contents</h3>
+            <h3>{% trans "Contents" %}</h3>
             <ul>
                 {% block sidebar_mobile %}{% endblock %}
             </ul>

--- a/templates/base_modal.html
+++ b/templates/base_modal.html
@@ -1,3 +1,5 @@
+{% load i18n %}
+
 <div class="modal-header" >
   <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 </div>

--- a/templates/composition/create.html
+++ b/templates/composition/create.html
@@ -10,9 +10,9 @@
 <div class="row">
     <h2>
         <i class="fa fa-fw fa-sitemap"></i>
-        Unit relationships
+        {% trans "Unit relationships" %}
     </h2>
-    <p>Describe how units are related to one another in <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{ source.published_on|date:"F d, Y"}})</p>
+    <p>{% trans "Describe how units are related to one another in" %} <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{ source.published_on|date:"F d, Y"}})</p>
     <hr />
 </div>
 <div class="row">
@@ -24,9 +24,9 @@
                 <div id="form-{{ forloop.counter0 }}-wrapper">
                 <input type="hidden" value="{{ organization.id }}" name="form-{{ forloop.counter0 }}-organization" />
                 <h4>
-                    Relationships for <strong>{{ organization.name }}</strong>
+                    {% trans "Relationships for" %} <strong>{{ organization.name }}</strong>
                     <button class="btn btn-link btn-sm remove-relationship" type="button" data-form_id="{{ forloop.counter0 }}">
-                        <i class="fa fa-fw fa-times"> </i> Remove this relationship
+                        <i class="fa fa-fw fa-times"> </i> {% trans "Remove this relationship" %}
                     </button>
 
                 </h4>
@@ -35,7 +35,7 @@
                 {% else %}
                     <div class="form-group">
                 {% endif %}
-                        <label class="col-sm-2 control-label">Relationship type</label>
+                        <label class="col-sm-2 control-label">{% trans "Relationship type" %}</label>
                         <div class="col-sm-8">
                             <select id="id_form-{{ forloop.counter0 }}-relationship_type" class="form-control" name="form-{{ forloop.counter0 }}-relationship_type">
                                 {% for type in relationship_types %}
@@ -58,7 +58,7 @@
                 {% else %}
                     <div class="form-group">
                 {% endif %}
-                        <label class="col-sm-2 control-label">Related organization</label>
+                        <label class="col-sm-2 control-label">{% trans "Related organization" %}</label>
                         <div class="col-sm-8">
                             <select id="id_form-{{ forloop.counter0 }}-related_organization" class="form-control organization-field" name="form-{{ forloop.counter0 }}-related_organization">
                                 <option value="" selected="selected">--------</option>
@@ -84,7 +84,7 @@
                 {% else %}
                     <div class="form-group">
                 {% endif %}
-                        <label class="col-sm-2 control-label">Relationship classification</label>
+                        <label class="col-sm-2 control-label">{% trans "Relationship classification" %}</label>
                         <div class="col-sm-8">
                             <select id="id_form-{{ forloop.counter0 }}-classification" class="form-control classification-field" name="form-{{ forloop.counter0 }}-classification">
                                     <option value="" selected="selected">--------</option>

--- a/templates/composition/edit.html
+++ b/templates/composition/edit.html
@@ -16,7 +16,7 @@
   <form>
     <div class="row">
       <div class="col-sm-12">
-        <h3>Properties</h3>
+        <h3>{% trans "Properties" %}</h3>
       </div>
     </div>
 
@@ -34,7 +34,7 @@
 
     <div class="row">
       <div class="col-sm-12">
-        <h3>Relations</h3>
+        <h3>{% trans "Relations" %}</h3>
       </div>
     </div>
 

--- a/templates/delete_confirm.html
+++ b/templates/delete_confirm.html
@@ -15,7 +15,7 @@
     </div>
     <div class="row">
       <div class="col-sm-12 col-md-12">
-        <a href="/{{model}}/" class="btn sfm-btn-default " type="submit">Cancel</a>
+        <a href="/{{model}}/" class="btn sfm-btn-default " type="submit">{% trans "Cancel" %}</a>
         <input class="btn pull-right sfm-btn-action" type="submit" value="{% trans "Delete" %}" />
       </div>
     </div>

--- a/templates/emplacement/edit.html
+++ b/templates/emplacement/edit.html
@@ -8,13 +8,13 @@
     <div class="inner-title-wrapper">
       <h1 class="page-title">{% trans "Emplacement" %}</h1>
       <div class="pull-right">
-        <a href="/emplacement/add/" class="btn sfm-btn-action"><i class="fa fa-plus"> Add New</i></a>
+        <a href="/emplacement/add/" class="btn sfm-btn-action"><i class="fa fa-plus"> {% trans "Add New" %}</i></a>
       </div>
     </div>
   </div>
   <div class="row">
     <div class="col-sm-12">
-      <h4>Properties</h4>
+      <h4>{% trans "Properties" %}</h4>
     </div>
   </div>
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -22,14 +23,14 @@
     <h2 class="form-signin-heading text-center">Security Force Monitor</h2>
     <form class="form-signin">
 
-      <label for="inputEmail" class="sr-only">Email address</label>
+      <label for="inputEmail" class="sr-only">{% trans "Email address" %}</label>
       <input type="email" id="inputEmail" class="form-control" placeholder="Email address" required autofocus>
-      <label for="inputPassword" class="sr-only">Password</label>
+      <label for="inputPassword" class="sr-only">{% trans "Password" %}</label>
       <input type="password" id="inputPassword" class="form-control" placeholder="Password" required>
       <div class="checkbox">
-        <a href="#"> Forgot Password? </a>
+        <a href="#"> {% trans "Forgot Password?" %} </a>
       </div>
-      <button class="btn btn-lg sfm-btn-action" type="submit">Sign in</button>
+      <button class="btn btn-lg sfm-btn-action" type="submit">{% trans "Sign in" %}</button>
     </form>
 
   </div> <!-- /container -->

--- a/templates/membershiporganization/create.html
+++ b/templates/membershiporganization/create.html
@@ -66,7 +66,7 @@
                 {% else %}
                     <div class="form-group">
                 {% endif %}
-                        <label class="control-label col-sm-2" for="id_form-{{ forloop.counter0 }}-firstciteddate">{% trans "First & last citation dates" %}</label>
+                        <label class="control-label col-sm-2" for="id_form-{{ forloop.counter0 }}-firstciteddate">{% trans "First and last citation dates" %}</label>
                         <div class="col-sm-4">
                             <input type="text" class="form-control datepicker" id="id_form-{{ forloop.counter0 }}-firstciteddate" name="form-{{ forloop.counter0 }}-startdate" value="{{ form.cleaned_data.startdate|date:'Y-m-d' }}"/>
                             {% if form.firstciteddate.errors %}

--- a/templates/membershiporganization/create.html
+++ b/templates/membershiporganization/create.html
@@ -14,9 +14,9 @@
         <i class="fa fa-users"></i>
         <small><i class="fa fa-arrow-left"></i></small>
         <small><i class="fa fa-users"></i></small>
-        Unit memberships</h2>
+        {% trans "Unit memberships" %}</h2>
     <p>
-        Describe which organizations (if any) are members of one another in
+        {% trans "Describe which organizations (if any) are members of one another in" %}
         <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{source.published_on|date:"F d, Y"}})
     </p>
     <hr />
@@ -30,9 +30,9 @@
                 <div id="form-{{ forloop.counter0 }}-wrapper">
                 <input type="hidden" value="{{ organization.id }}" name="form-{{ forloop.counter0 }}-member" />
                 <h4>
-                    Memberships for <strong>{{ organization.name }}</strong>
+                    {% trans "Memberships for" %} <strong>{{ organization.name }}</strong>
                     <button class="btn btn-link btn-sm remove-relationship" type="button" data-form_id="{{ forloop.counter0 }}">
-                        <i class="fa fa-times"> </i> Remove this membership
+                        <i class="fa fa-times"> </i> {% trans "Remove this membership" %}
                     </button>
 
                 </h4>
@@ -41,7 +41,7 @@
                 {% else %}
                     <div class="form-group">
                 {% endif %}
-                        <label class="col-sm-2 control-label">Organization</label>
+                        <label class="col-sm-2 control-label">{% trans "Organization" %}</label>
                         <div class="col-sm-8">
                             <select id="id_form-{{ forloop.counter0 }}-organization" class="form-control organization-field" name="form-{{ forloop.counter0 }}-organization">
                                 {% for org in organizations %}
@@ -66,7 +66,7 @@
                 {% else %}
                     <div class="form-group">
                 {% endif %}
-                        <label class="control-label col-sm-2" for="id_form-{{ forloop.counter0 }}-firstciteddate">First & last citation dates</label>
+                        <label class="control-label col-sm-2" for="id_form-{{ forloop.counter0 }}-firstciteddate">{% trans "First & last citation dates" %}</label>
                         <div class="col-sm-4">
                             <input type="text" class="form-control datepicker" id="id_form-{{ forloop.counter0 }}-firstciteddate" name="form-{{ forloop.counter0 }}-startdate" value="{{ form.cleaned_data.startdate|date:'Y-m-d' }}"/>
                             {% if form.firstciteddate.errors %}

--- a/templates/membershipperson/create.html
+++ b/templates/membershipperson/create.html
@@ -52,7 +52,7 @@
             {% else %}
             <div class="form-group">
             {% endif %}
-                <label class="control-label col-sm-2">{% trans "Role & Rank" %}</label>
+                <label class="control-label col-sm-2">{% trans "Role and Rank" %}</label>
                 <div class="col-sm-4">
                     <select id="id_form-{{ form_id }}-role" class="form-control role-field" name="form-{{ form_id }}-role">
                         <option value="" selected="selected">-- {% trans "Select a Role" %} --</option>

--- a/templates/membershipperson/create.html
+++ b/templates/membershipperson/create.html
@@ -12,8 +12,8 @@
 {% block content %}
 {% include 'partials/nav-wizard.html' %}
 <div class="row">
-    <h2><i class="fa fa-fw fa-sitemap"></i> Positions</h2>
-    <p>Describe positions held by personnel in <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{ source.published_on|date:"F d, Y"}})</p>
+    <h2><i class="fa fa-fw fa-sitemap"></i> {% trans "Positions" %}</h2>
+    <p>{% trans "Describe positions held by personnel in" %} <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{ source.published_on|date:"F d, Y"}})</p>
     <hr />
 </div>
 <form method="post" action="" id="person-form" class="form-horizontal">
@@ -37,7 +37,7 @@
             {% else %}
             <div class="form-group">
             {% endif %}
-                <label class="control-label col-sm-2" for="id_form-{{ form_id }}-title">Title</label>
+                <label class="control-label col-sm-2" for="id_form-{{ form_id }}-title">{% trans "Title" %}</label>
                 <div class="col-sm-8">
                    <input type="text" class="form-control title-field" id="id_form-{{ form_id }}-title" name="form-{{ form_id }}-title" value="{{ form.cleaned_data.title }}" />
                     {% if form.title.errors %}
@@ -52,10 +52,10 @@
             {% else %}
             <div class="form-group">
             {% endif %}
-                <label class="control-label col-sm-2">Role & Rank</label>
+                <label class="control-label col-sm-2">{% trans "Role & Rank" %}</label>
                 <div class="col-sm-4">
                     <select id="id_form-{{ form_id }}-role" class="form-control role-field" name="form-{{ form_id }}-role">
-                        <option value="" selected="selected">-- Select a Role --</option>
+                        <option value="" selected="selected">-- {% trans "Select a Role" %} --</option>
                         {% for role in roles %}
                         <option value="{{ role.id }}">{{ role.value }}</option>
                         {% endfor %}
@@ -69,7 +69,7 @@
                 </div>
                 <div class="col-sm-4">
                     <select id="id_form-{{ form_id }}-rank" class="form-control rank-field" name="form-{{ form_id }}-rank">
-                        <option value="" selected="selected">-- Select a Rank --</option>
+                        <option value="" selected="selected">-- {% trans "Select a Rank" %} --</option>
                         {% for rank in ranks %}
                         <option value="{{ rank.id }}">{{ rank.value }}</option>
                         {% endfor %}
@@ -87,7 +87,7 @@
             {% else %}
             <div class="form-group">
             {% endif %}
-                <label class="control-label col-sm-2" for="id_form-{{ form_id }}-startcontext">Start context</label>
+                <label class="control-label col-sm-2" for="id_form-{{ form_id }}-startcontext">{% trans "Start context" %}</label>
                 <div class="col-sm-6">
                    <input type="text" class="form-control start-context-field" id="id_form-{{ form_id }}-startcontext" name="form-{{ form_id }}-startcontext" value="{{ form.cleaned_data.startcontext }}" />
                     {% if form.startcontext.errors %}
@@ -99,9 +99,9 @@
                 <div class="col-sm-2">
                     <label for="id_form-{{ form_id }}-realstart" class="checkbox-inline">
                         {% if form.cleaned_data.realstart %}
-                            <input type="checkbox" id="id_form-{{ form_id }}-realstart" name="form-{{ form_id }}-realstart" checked > Real context?
+                            <input type="checkbox" id="id_form-{{ form_id }}-realstart" name="form-{{ form_id }}-realstart" checked > {% trans "Real context?" %}
                         {% else %}
-                            <input type="checkbox" id="id_form-{{ form_id }}-realstart" name="form-{{ form_id }}-realstart" > Real context?
+                            <input type="checkbox" id="id_form-{{ form_id }}-realstart" name="form-{{ form_id }}-realstart" > {% trans "Real context?" %}
                         {% endif %}
                     </label>
                     {% if form.realstart.errors %}
@@ -116,7 +116,7 @@
             {% else %}
             <div class="form-group">
             {% endif %}
-                <label class="control-label col-sm-2" for="id_form-{{ form_id }}-endcontext">End context</label>
+                <label class="control-label col-sm-2" for="id_form-{{ form_id }}-endcontext">{% trans "End context" %}</label>
                 <div class="col-sm-6">
                    <input type="text" class="form-control end-context-field" id="id_form-{{ form_id }}-endcontext" name="form-{{ form_id }}-endcontext" value="{{ form.cleaned_data.endcontext }}" />
                     {% if form.endcontext.errors %}
@@ -128,9 +128,9 @@
                 <div class="col-sm-2">
                     <label for="id_form-{{ form_id }}-realend" class="checkbox-inline">
                         {% if form.cleaned_data.realend %}
-                            <input type="checkbox" id="id_form-{{ form_id }}-realend" name="form-{{ form_id }}-realend" checked > Real context?
+                            <input type="checkbox" id="id_form-{{ form_id }}-realend" name="form-{{ form_id }}-realend" checked > {% trans "Real context?" %}
                         {% else %}
-                            <input type="checkbox" id="id_form-{{ form_id }}-realend" name="form-{{ form_id }}-realend" > Real context?
+                            <input type="checkbox" id="id_form-{{ form_id }}-realend" name="form-{{ form_id }}-realend" > {% trans "Real context?" %}
                         {% endif %}
                     </label>
                     {% if form.realend.errors %}
@@ -145,7 +145,7 @@
             {% else %}
                 <div class="form-group">
             {% endif %}
-                <label class="control-label col-sm-2" for="id_form-{{ form_id }}-firstciteddate">Citation dates</label>
+                <label class="control-label col-sm-2" for="id_form-{{ form_id }}-firstciteddate">{% trans "Citation dates" %}</label>
                 <div class="col-sm-4">
                     <input type="text" class="form-control datepicker" id="id_form-{{ form_id }}-firstciteddate" name="form-{{ form_id }}-firstciteddate" value="{{ form.cleaned_data.firstciteddate|date:'Y-m-d' }}" placeholder="First cited date" />
                     {% if form.firstciteddate.errors %}

--- a/templates/membershipperson/edit.html
+++ b/templates/membershipperson/edit.html
@@ -33,7 +33,7 @@
     {% else %}
     <div class="form-group">
     {% endif %}
-        <label class="control-label col-sm-2">{% trans "Role & Rank" %}</label>
+        <label class="control-label col-sm-2">{% trans "Role and Rank" %}</label>
         <div class="col-sm-4">
             <select id="id_role" class="form-control" name="role">
                 <option value="" selected="selected">-- {% trans "Select a Role" %} --</option>

--- a/templates/membershipperson/edit.html
+++ b/templates/membershipperson/edit.html
@@ -9,7 +9,7 @@
     <h1 class="page-title">
         {{ source_object.member.get_value }}
         <br />
-        <small>member of {{ source_object.organization.get_value }}</small>
+        <small>{% trans "member of" %} {{ source_object.organization.get_value }}</small>
     </h1>
 {% endblock %}
 {% block form_guts %}
@@ -18,7 +18,7 @@
     {% else %}
     <div class="form-group">
     {% endif %}
-        <label class="control-label col-sm-2" for="id_title">Title</label>
+        <label class="control-label col-sm-2" for="id_title">{% trans "Title" %}</label>
         <div class="col-sm-8">
             <input type="text" class="form-control" id="id_title" name="title" value="{{ form_data.title.value }}"/>
             {% if form.title.errors %}
@@ -33,10 +33,10 @@
     {% else %}
     <div class="form-group">
     {% endif %}
-        <label class="control-label col-sm-2">Role & Rank</label>
+        <label class="control-label col-sm-2">{% trans "Role & Rank" %}</label>
         <div class="col-sm-4">
             <select id="id_role" class="form-control" name="role">
-                <option value="" selected="selected">-- Select a Role --</option>
+                <option value="" selected="selected">-- {% trans "Select a Role" %} --</option>
                 {% for role in roles %}
                     {% if role = form_data.role %}
                         <option value="{{ role.id }}" selected=true>{{ role.value }}</option>
@@ -53,7 +53,7 @@
         </div>
         <div class="col-sm-4">
             <select id="id_rank" class="form-control" name="rank">
-                <option value="" selected="selected">-- Select a Rank --</option>
+                <option value="" selected="selected">-- {% trans "Select a Rank" %} --</option>
                 {% for rank in ranks %}
                     {% if rank = form_data.rank %}
                         <option value="{{ rank.id }}" selected=true>{{ rank.value }}</option>
@@ -74,7 +74,7 @@
     {% else %}
     <div class="form-group">
     {% endif %}
-        <label class="control-label col-sm-2" for="id_startcontext">Start context</label>
+        <label class="control-label col-sm-2" for="id_startcontext">{% trans "Start context" %}</label>
         <div class="col-sm-6">
             <input type="text" class="form-control" id="id_startcontext" name="startcontext" {% if form_data.startcontext %}value="{{ form_data.startcontext }}"{% endif %} />
             {% if form.startcontext.errors %}
@@ -86,9 +86,9 @@
         <div class="col-sm-2">
             <label for="id_realstart" class="checkbox-inline">
                 {% if form_data.realstart %}
-                    <input type="checkbox" id="id_realstart" name="realstart" checked > Real context?
+                    <input type="checkbox" id="id_realstart" name="realstart" checked > {% trans "Real context?" %}
                 {% else %}
-                    <input type="checkbox" id="id_realstart" name="realstart" > Real context?
+                    <input type="checkbox" id="id_realstart" name="realstart" > {% trans "Real context?" %}
                 {% endif %}
             </label>
             {% if form.realstart.errors %}
@@ -103,7 +103,7 @@
     {% else %}
     <div class="form-group">
     {% endif %}
-        <label class="control-label col-sm-2" for="id_endcontext">End context</label>
+        <label class="control-label col-sm-2" for="id_endcontext">{% trans "End context" %}</label>
         <div class="col-sm-6">
            <input type="text" class="form-control" id="id_endcontext" name="endcontext" {% if form_data.endcontext %}value="{{ form_data.endcontext }}"{% endif %} />
             {% if form.endcontext.errors %}
@@ -115,9 +115,9 @@
         <div class="col-sm-2">
             <label for="id_realend" class="checkbox-inline">
                 {% if form_data.realend %}
-                    <input type="checkbox" id="id_realend" name="realend" checked > Real context?
+                    <input type="checkbox" id="id_realend" name="realend" checked > {% trans "Real context?" %}
                 {% else %}
-                    <input type="checkbox" id="id_realend" name="realend" > Real context?
+                    <input type="checkbox" id="id_realend" name="realend" > {% trans "Real context?" %}
                 {% endif %}
             </label>
             {% if form.realend.errors %}
@@ -132,7 +132,7 @@
     {% else %}
         <div class="form-group">
     {% endif %}
-        <label class="control-label col-sm-2" for="id_firstciteddate">Citation dates</label>
+        <label class="control-label col-sm-2" for="id_firstciteddate">{% trans "Citation dates" %}</label>
         <div class="col-sm-4">
             <input type="text" class="form-control datepicker" id="id_firstciteddate" name="firstciteddate" value="{{ form_data.firstciteddate|date:'Y-m-d' }}" placeholder="First cited date" />
             {% if form.firstciteddate.errors %}

--- a/templates/membershipperson/search.html
+++ b/templates/membershipperson/search.html
@@ -6,7 +6,7 @@
     <div class="inner-title-wrapper">
       <h1 class="page-title">{% trans "Search a person membership" %}</h1>
       <div class="pull-right">
-        <a href="/membershipperson/add/" class="btn sfm-btn-action"><i class="fa fa-plus"> Add New</i></a>
+        <a href="/membershipperson/add/" class="btn sfm-btn-action"><i class="fa fa-plus"> {% trans "Add New" %}</i></a>
       </div>
     </div>
   </div>

--- a/templates/modals/translate.html
+++ b/templates/modals/translate.html
@@ -6,20 +6,20 @@
 <div class="modal-body row">
   <div class="modal_tr_info col-sm-8">
     <ul class="languages_list">
-      <h5 class="col-sm-6">Language</h5>
-      <h5 class="col-sm-6">Translation</h5>
+      <h5 class="col-sm-6">{% trans "Language" %}</h5>
+      <h5 class="col-sm-6">{% trans "Translation" %}</h5>
     </ul>
   </div>
   <div class="modal_tr_add col-sm-4">
-    <p>Add a Language:</p>
+    <p>{% trans "Add a Language:" %}</p>
     <div class="row">
       <input type="text" class="form-control col-sm-12 --lang-name" placeholder="Start typing...">
       <input type="hidden" class="form-control col-sm-12 --lang-code">
       <input type="text" class="form-control col-sm-12 --lang-trans" placeholder="Enter Translation">
     </div>
-    <button type="button" class="btn sfm-btn-action center-block addTranslation --lang-add-btn" >Add</btn>
+    <button type="button" class="btn sfm-btn-action center-block addTranslation --lang-add-btn" >{% trans "Add" %}</btn>
     </div>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn sfm-btn-cancel" data-dismiss="modal">Close</button>
+    <button type="button" class="btn sfm-btn-cancel" data-dismiss="modal">{% trans "Close" %}</button>
   </div>

--- a/templates/modals/version.html
+++ b/templates/modals/version.html
@@ -6,13 +6,13 @@
 <div class="modal-body row">
 	<div class="people_vr_info col-sm-8">
 		<ul class="versions_list">
-			<h5 class="col-sm-4">Versions</h5>
-			<h5 class="col-sm-6">Sources</h5>
-			<h5 class="col-sm-2">Revert</h5>
+			<h5 class="col-sm-4">{% trans "Versions" %}</h5>
+			<h5 class="col-sm-6">{% trans "Sources" %}</h5>
+			<h5 class="col-sm-2">{% trans "Revert" %}</h5>
 		</ul>
 	</div>
 	<div class="modal_vr_add col-sm-4">
-		<p>Choose Language</p>
+		<p>{% trans "Choose Language" %}</p>
 		<div class="row">
 			<select class="--ver-lang">
 				{% for lang in langs %}
@@ -23,5 +23,5 @@
 	</div>
 </div>
 <div class="modal-footer">
-	<button type="button" class="btn sfm-btn-cancel" data-dismiss="modal">Close</button>
+	<button type="button" class="btn sfm-btn-cancel" data-dismiss="modal">{% trans "Close" %}</button>
 </div>

--- a/templates/organization/create-geography.html
+++ b/templates/organization/create-geography.html
@@ -109,7 +109,7 @@
                 {% else %}
                     <div class="form-group">
                 {% endif %}
-                        <label class="control-label col-sm-2" for="id_form-{{ form_id }}-startdate">{% trans "Start & end dates" %}</label>
+                        <label class="control-label col-sm-2" for="id_form-{{ form_id }}-startdate">{% trans "Start and end dates" %}</label>
                         <div class="col-sm-4">
                             <input type="text" class="form-control datepicker" id="id_form-{{ form_id }}-startdate" name="form-{{ form_id }}-startdate" value="{{ form.cleaned_data.startdate|date:'Y-m-d' }}"/>
                             {% if form.startdate.errors %}
@@ -196,7 +196,7 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="control-label col-sm-2" for="id_form-<%= form_id %>-startdate">{% trans "Start & end dates" %}</label>
+            <label class="control-label col-sm-2" for="id_form-<%= form_id %>-startdate">{% trans "Start and end dates" %}</label>
             <div class="col-sm-4">
                 <input type="text" class="form-control datepicker" id="id_form-<%= form_id %>-startdate" name="form-<%= form_id %>-startdate"  placeholder="Start date" />
             </div>

--- a/templates/organization/create-geography.html
+++ b/templates/organization/create-geography.html
@@ -11,8 +11,8 @@
 {% block content %}
 {% include 'partials/nav-wizard.html' %}
 <div class="row">
-    <h2><i class="fa fa-fw fa-map-marker"></i> Geographies</h2>
-    <p>Describe any geographies related to organizations found in <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{ source.published_on|date:"F d, Y"}})</p>
+    <h2><i class="fa fa-fw fa-map-marker"></i> {% trans "Geographies" %}</h2>
+    <p>{% trans "Describe any geographies related to organizations found in" %} <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{ source.published_on|date:"F d, Y"}})</p>
     <hr />
 </div>
 <form method="post" action="" class="form-horizontal">
@@ -29,7 +29,7 @@
                     {% else %}
                         <div class="form-group">
                     {% endif %}
-                            <label class="control-label col-sm-2" for="id_form-{{ form_id }}-org">Organization </label>
+                            <label class="control-label col-sm-2" for="id_form-{{ form_id }}-org">{% trans "Organization" %} </label>
                             <div class="col-sm-8">
                                 <select id="id_form-{{ form_id }}-org" class="form-control org-field" name="form-{{ form_id }}-org">
                                     {% for organization in organizations %}
@@ -48,7 +48,7 @@
                     {% else %}
                         <div class="form-group">
                     {% endif %}
-                            <label class="control-label col-sm-2">Geography type</label>
+                            <label class="control-label col-sm-2">{% trans "Geography type" %}</label>
                             <div class="col-sm-8">
                                 <select id="id_form-{{ form_id }}-geography_type" class="geography-type form-control" name="form-{{ form_id }}-geography_type">
                                     <option value="">--------</option>
@@ -72,7 +72,7 @@
                     {% else %}
                         <div class="form-group">
                     {% endif %}
-                            <label class="control-label col-sm-2">Name</label>
+                            <label class="control-label col-sm-2">{% trans "Name" %}</label>
                             <div class="col-sm-8">
                                 <input type="text" name="form-{{ form_id }}-name" id="id_form-{{ form_id }}-name" value="{{ form.cleaned_data.name }}" class="form-control" />
                                 {% if form.name.errors %}
@@ -87,7 +87,7 @@
                     {% else %}
                         <div class="form-group">
                     {% endif %}
-                            <label class="control-label col-sm-2" for="id_form-{{ form_id }}-osm_id">OSM ID</label>
+                            <label class="control-label col-sm-2" for="id_form-{{ form_id }}-osm_id">{% trans "OSM ID" %}</label>
                             <div class="col-sm-8">
                                 <select class="form-control" class="osm_id-field" id="id_form-{{ form_id }}-osm_id" name="form-{{ form_id }}-osm_id">
                                     {% if form.cleaned_data.osmname %}
@@ -109,7 +109,7 @@
                 {% else %}
                     <div class="form-group">
                 {% endif %}
-                        <label class="control-label col-sm-2" for="id_form-{{ form_id }}-startdate">Start & end dates</label>
+                        <label class="control-label col-sm-2" for="id_form-{{ form_id }}-startdate">{% trans "Start & end dates" %}</label>
                         <div class="col-sm-4">
                             <input type="text" class="form-control datepicker" id="id_form-{{ form_id }}-startdate" name="form-{{ form_id }}-startdate" value="{{ form.cleaned_data.startdate|date:'Y-m-d' }}"/>
                             {% if form.startdate.errors %}
@@ -134,7 +134,7 @@
     </div>
     <div class="form-group">
         <div class="col-sm-12" id="manage-forms">
-            <button id="add-form" type="button" class="btn btn-link"><i class="fa fa-fw fa-plus-circle"></i> Add another geography</button>
+            <button id="add-form" type="button" class="btn btn-link"><i class="fa fa-fw fa-plus-circle"></i> {% trans "Add another geography" %}</button>
         </div>
     </div>
     <br />
@@ -161,7 +161,7 @@
 <script id="formTemplate" type="text/EJS">
     <div id="form-<%= form_id %>-wrapper">
         <div class="form-group">
-            <label class="control-label col-sm-2" for="id_form-<%= form_id %>-org">Organization </label>
+            <label class="control-label col-sm-2" for="id_form-<%= form_id %>-org">{% trans "Organization" %} </label>
             <div class="col-sm-8">
                 <select id="id_form-<%= form_id %>-org" class="form-control org-field" name="form-<%= form_id %>-org">
                     {% for organization in organizations %}
@@ -171,7 +171,7 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="control-label col-sm-2">Geography type</label>
+            <label class="control-label col-sm-2">{% trans "Geography type" %}</label>
             <div class="col-sm-8">
                 <select id="id_form-<%= form_id %>-geography_type" class="geography-type form-control" name="form-<%= form_id %>-geography_type">
                     <option value="">--------</option>
@@ -182,13 +182,13 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="control-label col-sm-2">Name</label>
+            <label class="control-label col-sm-2">{% trans "Name" %}</label>
             <div class="col-sm-8">
                 <input type="text" name="form-<%= form_id %>-name" id="id_form-<%= form_id %>-name" class="form-control" />
             </div>
         </div>
         <div class="form-group">
-            <label class="control-label col-sm-2" for="id_form-<%= form_id %>-osmname">OSM Name</label>
+            <label class="control-label col-sm-2" for="id_form-<%= form_id %>-osmname">{% trans "OSM Name" %}</label>
             <div class="col-sm-8">
                 <select class="form-control" id="id_form-<%= form_id %>-osm_id" name="form-<%= form_id %>-osm_id"></select>
                 <input type="hidden" name="form-<%= form_id %>-osm_id_text" id="id_form-<%= form_id %>-osm_id_text" />
@@ -196,7 +196,7 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="control-label col-sm-2" for="id_form-<%= form_id %>-startdate">Start & end dates</label>
+            <label class="control-label col-sm-2" for="id_form-<%= form_id %>-startdate">{% trans "Start & end dates" %}</label>
             <div class="col-sm-4">
                 <input type="text" class="form-control datepicker" id="id_form-<%= form_id %>-startdate" name="form-<%= form_id %>-startdate"  placeholder="Start date" />
             </div>
@@ -208,7 +208,7 @@
             <div class="form-group">
                 <div class="col-sm-10 col-sm-offset-2">
                     <button id="remove_form-<%= form_id %>" type="button" class="remove-form btn btn-link">
-                        <i class="fa fa-fw fa-times"></i> Remove this geography
+                        <i class="fa fa-fw fa-times"></i> {% trans "Remove this geography" %}
                     </button>
                 </div>
             </div>

--- a/templates/organization/create.html
+++ b/templates/organization/create.html
@@ -11,8 +11,8 @@
 {% block content %}
 {% include 'partials/nav-wizard.html' %}
 <div class="row">
-    <h2><i class="fa fa-fw fa-users"></i> Units</h2>
-    <p>Describe any units found in <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{ source.published_on|date:"F d, Y"}})</p>
+    <h2><i class="fa fa-fw fa-users"></i> {% trans "Units" %}</h2>
+    <p>{% trans "Describe any units found in" %} <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{ source.published_on|date:"F d, Y"}})</p>
     <hr />
 </div>
 <div class="row">
@@ -30,7 +30,7 @@
                         {% else %}
                             <div class="form-group">
                         {% endif %}
-                            <label class="col-sm-2 control-label">Unit name</label>
+                            <label class="col-sm-2 control-label">{% trans "Unit name" %}</label>
                             <div class="col-sm-8">
                                 <select id="id_form-{{ form_id }}-name" class="form-control name-field" name="form-{{ form_id }}-name">
                                         <option value="" selected="selected">--------</option>
@@ -51,7 +51,7 @@
                         {% else %}
                             <div class="form-group">
                         {% endif %}
-                            <label class="col-sm-2 control-label">Aliases</label>
+                            <label class="col-sm-2 control-label">{% trans "Aliases" %}</label>
                             <div class="col-sm-8">
                                 <select id="id_form-{{ form_id }}-alias" class="form-control alias-field" name="form-{{ form_id }}-alias" multiple="multiple">
                                     {% for alias in form.aliases %}
@@ -73,7 +73,7 @@
                         {% else %}
                             <div class="form-group">
                         {% endif %}
-                            <label class="col-sm-2 control-label">Classification </label>
+                            <label class="col-sm-2 control-label">{% trans "Classification" %} </label>
                             <div class="col-sm-8">
                                 <select id="id_form-{{ form_id }}-classification" class="form-control class-field" name="form-{{ form_id }}-classification" multiple="multiple">
                                     {% for classification in form.classifications %}
@@ -95,7 +95,7 @@
                         {% else %}
                             <div class="form-group">
                         {% endif %}
-                            <label class="col-sm-2 control-label">Division identifier</label>
+                            <label class="col-sm-2 control-label">{% trans "Division identifier" %}</label>
                             <div class="col-sm-8">
                                 <select id="id_form-{{ form_id }}-division_id" class="form-control division_id-field" name="form-{{ form_id }}-division_id">
                                         <option value="" selected="selected">--------</option>
@@ -160,7 +160,7 @@
 <script type="text/EJS" id="formTemplate">
     <div id="form-<%= form_id %>-wrapper">
         <div class="form-group">
-            <label class="col-sm-2 control-label">Unit name</label>
+            <label class="col-sm-2 control-label">{% trans "Unit name" %}</label>
             <div class="col-sm-8">
                 <select id="id_form-<%= form_id %>-name" class="form-control" name="form-<%= form_id %>-name">
                     <option value="" selected="selected">--------</option>
@@ -169,21 +169,21 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="col-sm-2 control-label">Aliases</label>
+            <label class="col-sm-2 control-label">{% trans "Aliases" %}</label>
             <div class="col-sm-8">
                 <select id="id_form-<%= form_id %>-alias" class="form-control" name="form-<%= form_id %>-alias" multiple="multiple">
                 </select>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-sm-2 control-label">Classification</label>
+            <label class="col-sm-2 control-label">{% trans "Classification" %}</label>
             <div class="col-sm-8">
                 <select id="id_form-<%= form_id %>-classification" class="form-control class-field" name="form-<%= form_id %>-classification" multiple="multiple">
                 </select>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-sm-2 control-label">Division identifier</label>
+            <label class="col-sm-2 control-label">{% trans "Division identifier" %}</label>
             <div class="col-sm-8">
                 <select id="id_form-<%= form_id %>-division_id" class="form-control" name="form-<%= form_id %>-division_id">
                     <option value="" selected="selected">--------</option>
@@ -195,7 +195,7 @@
             <div class="form-group">
                 <div class="col-sm-10 col-sm-offset-2">
                     <button id="remove_form-<%= form_id %>" href="javascript://" type="button" class="remove-form btn btn-link">
-                        <i class="fa fa-fw fa-times"></i> Remove this unit
+                        <i class="fa fa-fw fa-times"></i> {% trans "Remove this unit" %}
                     </button>
                 </div>
             </div>

--- a/templates/organization/detail.html
+++ b/templates/organization/detail.html
@@ -17,7 +17,7 @@
         </small>
     </h1>
     {% if organization.aliases.get_list %}
-        <p>Also known as:
+        <p>{% trans "Also known as:" %}
             {% for alias in organization.aliases.get_list %}
             <strong>{{ alias.get_value }}{% if not forloop.last %}|{% endif %} </strong>
             {% endfor %}
@@ -35,16 +35,16 @@
 {% block sidebar %}
     {% has_versions organization as changelog %}
 
-    {% if areas %}<li><a href="#areas-of-operation"><i class="fa fa-fw fa-globe"></i> Areas of operation </a></li>{% endif %}
-    {% if sites %}<li><a href="#sites"><i class="fa fa-fw fa-map-marker"></i> Sites</a></li>{% endif %}
-    {% if memberships %}<li><a href="#memberships"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> Memberships</a></li>{% endif %}
-    {% if org_members %}<li><a href="#org-members"><i class="fa fa-fw fa-sitemap"></i> Member units</a></li>{% endif %}
-    {% if parents %}<li><a href="#parent-units"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> Parent units</a></li>{% endif %}
-    {% if subsidiaries %}<li><a href="#subsidiaries"><i class="fa fa-fw fa-sitemap"></i> Subsidiaries</a></li>{% endif %}
-    {% if person_members %}<li><a href="#command-personnel"><i class="fa fa-fw fa-users"></i> Command personnel</a></li>{% endif %}
-    {% if violations %}<li><a href="incidents"><i class="fa fa-fw fa-exclamation-triangle"></i> Incidents</a></li>{% endif %}
-    {% if sources %}<li><a href="#sources"><i class="fa fa-fw fa-files-o"></i> Sources</a></li>{% endif %}
-    {% if changelog %}<li><a href="#changelog"><i class="fa fa-fw fa-refresh"></i> Changelog</a></li>{% endif %}
+    {% if areas %}<li><a href="#areas-of-operation"><i class="fa fa-fw fa-globe"></i> {% trans "Areas of operation" %} </a></li>{% endif %}
+    {% if sites %}<li><a href="#sites"><i class="fa fa-fw fa-map-marker"></i> {% trans "Sites" %}</a></li>{% endif %}
+    {% if memberships %}<li><a href="#memberships"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> {% trans "Memberships" %}</a></li>{% endif %}
+    {% if org_members %}<li><a href="#org-members"><i class="fa fa-fw fa-sitemap"></i> {% trans "Member units" %}</a></li>{% endif %}
+    {% if parents %}<li><a href="#parent-units"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> {% trans "Parent units" %}</a></li>{% endif %}
+    {% if subsidiaries %}<li><a href="#subsidiaries"><i class="fa fa-fw fa-sitemap"></i> {% trans "Subsidiaries" %}</a></li>{% endif %}
+    {% if person_members %}<li><a href="#command-personnel"><i class="fa fa-fw fa-users"></i> {% trans "Command personnel" %}</a></li>{% endif %}
+    {% if violations %}<li><a href="incidents"><i class="fa fa-fw fa-exclamation-triangle"></i> {% trans "Incidents" %}</a></li>{% endif %}
+    {% if sources %}<li><a href="#sources"><i class="fa fa-fw fa-files-o"></i> {% trans "Sources" %}</a></li>{% endif %}
+    {% if changelog %}<li><a href="#changelog"><i class="fa fa-fw fa-refresh"></i> {% trans "Changelog" %}</a></li>{% endif %}
 
 {% endblock %}
 
@@ -53,16 +53,16 @@
 {% block sidebar_mobile %}
     {% has_versions organization as changelog %}
 
-    {% if areas %}<li><a href="#areas-of-operation"><i class="fa fa-fw fa-globe"></i> Areas of operation </a></li>{% endif %}
-    {% if sites %}<li><a href="#sites"><i class="fa fa-fw fa-map-marker"></i> Sites</a></li>{% endif %}
-    {% if memberships %}<li><a href="#memberships"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> Memberships</a></li>{% endif %}
-    {% if org_members %}<li><a href="#org-members"><i class="fa fa-fw fa-sitemap"></i> Member units</a></li>{% endif %}
-    {% if memberships %}<li><a href="#parent-units"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> Parent units</a></li>{% endif %}
-    {% if subsidiaries %}<li><a href="#subsidiaries"><i class="fa fa-fw fa-sitemap"></i> Subsidiaries</a></li>{% endif %}
-    {% if person_members %}<li><a href="#command-personnel"><i class="fa fa-fw fa-users"></i> Command personnel</a></li>{% endif %}
-    {% if violations %}<li><a href="incidents"><i class="fa fa-fw fa-exclamation-triangle"></i> Incidents</a></li>{% endif %}
-    {% if sources %}<li><a href="#sources"><i class="fa fa-fw fa-files-o"></i> Sources</a></li>{% endif %}
-    {% if changelog %}<li><a href="#changelog"><i class="fa fa-fw fa-refresh"></i> Changelog</a></li>{% endif %}
+    {% if areas %}<li><a href="#areas-of-operation"><i class="fa fa-fw fa-globe"></i> {% trans "Areas of operation" %} </a></li>{% endif %}
+    {% if sites %}<li><a href="#sites"><i class="fa fa-fw fa-map-marker"></i> {% trans "Sites" %}</a></li>{% endif %}
+    {% if memberships %}<li><a href="#memberships"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> {% trans "Memberships" %}</a></li>{% endif %}
+    {% if org_members %}<li><a href="#org-members"><i class="fa fa-fw fa-sitemap"></i> {% trans "Member units" %}</a></li>{% endif %}
+    {% if parents %}<li><a href="#parent-units"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> {% trans "Parent units" %}</a></li>{% endif %}
+    {% if subsidiaries %}<li><a href="#subsidiaries"><i class="fa fa-fw fa-sitemap"></i> {% trans "Subsidiaries" %}</a></li>{% endif %}
+    {% if person_members %}<li><a href="#command-personnel"><i class="fa fa-fw fa-users"></i> {% trans "Command personnel" %}</a></li>{% endif %}
+    {% if violations %}<li><a href="incidents"><i class="fa fa-fw fa-exclamation-triangle"></i> {% trans "Incidents" %}</a></li>{% endif %}
+    {% if sources %}<li><a href="#sources"><i class="fa fa-fw fa-files-o"></i> {% trans "Sources" %}</a></li>{% endif %}
+    {% if changelog %}<li><a href="#changelog"><i class="fa fa-fw fa-refresh"></i> {% trans "Changelog" %}</a></li>{% endif %}
 
 {% endblock %}
 
@@ -71,7 +71,7 @@
     {% if areas %}
     <div class="row">
         <div class="col-sm-12">
-            <h3 id="areas-of-operation"><i class="fa fa-fw fa-globe"></i> Areas of operation</h3>
+            <h3 id="areas-of-operation"><i class="fa fa-fw fa-globe"></i> {% trans "Areas of operation" %}</h3>
             <hr />
             <div id="osm_area_map" style="height:300px;"></div>
         </div>
@@ -81,7 +81,7 @@
     {% if sites %}
     <div class="row">
         <div class="col-sm-12">
-            <h3 id="sites"><i class="fa fa-fw fa-map-marker"></i> Sites</h3>
+            <h3 id="sites"><i class="fa fa-fw fa-map-marker"></i> {% trans "Sites" %}</h3>
             <hr />
             <div id="osm_site_map" style="height:300px;"></div>
         </div>
@@ -93,18 +93,18 @@
         <div class="col-sm-12">
             <h3 id="parent-units">
                 <i class="fa fa-fw fa-sitemap fa-rotate-180"></i>
-                Memberships
-                <small>Multi-unit organizations that this unit is part of.</small>
+                {% trans "Memberships" %}
+                <small>{% trans "Multi-unit organizations that this unit is part of." %}</small>
             </h3>
             <hr />
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Aliases</th>
-                        <th>Classifications</th>
-                        <th>First cited</th>
-                        <th>Last cited</th>
+                        <th>{% trans "Name" %}</th>
+                        <th>{% trans "Aliases" %}</th>
+                        <th>{% trans "Classifications" %}</th>
+                        <th>{% trans "First cited" %}</th>
+                        <th>{% trans "Last cited" %}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -146,16 +146,16 @@
     {% if org_members %}
     <div class="row">
         <div class="col-sm-12">
-            <h3 id="org-members"><i class="fa fa-fw fa-sitemap"></i> Member units</h3>
+            <h3 id="org-members"><i class="fa fa-fw fa-sitemap"></i> {% trans "Member units" %}</h3>
             <hr />
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Aliases</th>
-                        <th>Classifications</th>
-                        <th>First cited</th>
-                        <th>Last cited</th>
+                        <th>{% trans "Name" %}</th>
+                        <th>{% trans "Aliases" %}</th>
+                        <th>{% trans "Classifications" %}</th>
+                        <th>{% trans "First cited" %}</th>
+                        <th>{% trans "Last cited" %}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -197,16 +197,16 @@
     {% if parents %}
     <div class="row">
         <div class="col-sm-12">
-            <h3 id="parent-units"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> Parent units</h3>
+            <h3 id="parent-units"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> {% trans "Parent units" %}</h3>
             <hr />
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Aliases</th>
-                        <th>Classifications</th>
-                        <th>First cited</th>
-                        <th>Last cited</th>
+                        <th>{% trans "Name" %}</th>
+                        <th>{% trans "Aliases" %}</th>
+                        <th>{% trans "Classifications" %}</th>
+                        <th>{% trans "First cited" %}</th>
+                        <th>{% trans "Last cited" %}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -248,16 +248,16 @@
     {% if subsidiaries %}
     <div class="row">
         <div class="col-sm-12">
-            <h3 id="subsidiaries"><i class="fa fa-fw fa-sitemap"></i> Subsidiaries</h3>
+            <h3 id="subsidiaries"><i class="fa fa-fw fa-sitemap"></i> {% trans "Subsidiaries" %}</h3>
             <hr />
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Aliases</th>
-                        <th>Classifications</th>
-                        <th>First cited</th>
-                        <th>Last cited</th>
+                        <th>{% trans "Name" %}</th>
+                        <th>{% trans "Aliases" %}</th>
+                        <th>{% trans "Classifications" %}</th>
+                        <th>{% trans "First cited" %}</th>
+                        <th>{% trans "Last cited" %}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -299,17 +299,17 @@
     {% if person_members %}
     <div class="row">
         <div class="col-sm-12">
-            <h3 id="command-personnel"><i class="fa fa-fw fa-users"></i> Command personnel</h3>
+            <h3 id="command-personnel"><i class="fa fa-fw fa-users"></i> {% trans "Command personnel" %}</h3>
             <hr />
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Rank</th>
-                        <th>Role</th>
-                        <th>Title</th>
-                        <th>Start date</th>
-                        <th>End date</th>
+                        <th>{% trans "Name" %}</th>
+                        <th>{% trans "Rank" %}</th>
+                        <th>{% trans "Role" %}</th>
+                        <th>{% trans "Title" %}</th>
+                        <th>{% trans "Start date" %}</th>
+                        <th>{% trans "End date" %}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -336,23 +336,23 @@
     {% if events %}
     <div class="row">
         <div class="col-sm-12">
-            <h3 id="incidents"><i class="fa fa-fw fa-exclamation-triangle"></i> Incidents</h3>
+            <h3 id="incidents"><i class="fa fa-fw fa-exclamation-triangle"></i> {% trans "Incidents" %}</h3>
             <hr />
             {% for event in events %}
                 <div class="row">
                     <div class="col-sm-12">
                         <p>
                             <a href="{% url 'detail_violation' event.id %}">
-                                Incident
+                                {% trans "Incident" %}
                                 {% if event.osmname %}
-                                    in <strong>{{ event.osmname }}</strong>
+                                    {% trans "in" %} <strong>{{ event.osmname }}</strong>
                                 {% endif %}
                                 {% if event.startdate and event.enddate %}
-                                    between <strong>{{ event.startdate }}</strong> and <strong>{{ event.enddate }}</strong>
+                                    {% trans "between" %} <strong>{{ event.startdate }}</strong> and <strong>{{ event.enddate }}</strong>
                                 {% elif event.startdate %}
-                                    starting <strong>{{ event.startdate }}</strong>
+                                    {% trans "starting" %} <strong>{{ event.startdate }}</strong>
                                 {% elif event.enddate %}
-                                    ending <strong>{{ event.enddate }}</strong>
+                                    {% trans "ending" %} <strong>{{ event.enddate }}</strong>
                                 {% endif %}
                             </a>
                         </p>

--- a/templates/organization/detail.html
+++ b/templates/organization/detail.html
@@ -384,8 +384,8 @@
         <script src="https://npmcdn.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
         <script type="text/javascript">
             $(document).ready(function(){
-                var center_x = {{ sites.0.coordinates.get_value.value.x }};
-                var center_y = {{ sites.0.coordinates.get_value.value.y }};
+                var center_x = {{ sites.0.coordinates.get_value.value.x|safe }};
+                var center_y = {{ sites.0.coordinates.get_value.value.y|safe }};
                 var site_map = L.map('osm_site_map').setView([center_y, center_x], 10);
                 var attribution = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>';
                 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/templates/organization/edit.html
+++ b/templates/organization/edit.html
@@ -16,7 +16,7 @@
     {% else %}
         <div class="form-group">
     {% endif %}
-        <label class="col-sm-2 control-label">Organization name</label>
+        <label class="col-sm-2 control-label">{% trans "Organization name" %}</label>
         <div class="col-sm-8">
             <select id="id_name" class="form-control name-field" name="name">
                     <option value="" selected="selected">--------</option>
@@ -37,7 +37,7 @@
     {% else %}
         <div class="form-group">
     {% endif %}
-        <label class="col-sm-2 control-label">Aliases</label>
+        <label class="col-sm-2 control-label">{% trans "Aliases" %}</label>
         <div class="col-sm-8">
             <select id="id_alias" class="form-control alias-field" name="alias" multiple="multiple">
                 {% for alias in form_data.alias %}
@@ -56,7 +56,7 @@
     {% else %}
         <div class="form-group">
     {% endif %}
-        <label class="col-sm-2 control-label">Classification </label>
+        <label class="col-sm-2 control-label">{% trans "Classification" %}</label>
         <div class="col-sm-8">
             <select id="id_classification" class="form-control class-field" name="classification" multiple="multiple">
                 {% for classification in form_data.classification %}
@@ -75,7 +75,7 @@
     {% else %}
         <div class="form-group">
     {% endif %}
-        <label class="col-sm-2 control-label">Division identifier</label>
+        <label class="col-sm-2 control-label">{% trans "Division identifier" %}</label>
         <div class="col-sm-8">
             <select id="id_division_id" class="form-control division_id-field" name="division_id">
                     <option value="" selected="selected">--------</option>

--- a/templates/organization/search.html
+++ b/templates/organization/search.html
@@ -6,7 +6,7 @@
     <div class="inner-title-wrapper">
       <h1 class="page-title">{% trans "Search an organization" %}</h1>
       <div class="pull-right">
-        <a href="/organization/add/" class="btn sfm-btn-action"><i class="fa fa-plus"></i> {% trans "Add New" %}{% trans "</" %}a>
+        <a href="/organization/add/" class="btn sfm-btn-action"><i class="fa fa-plus"></i> {% trans "Add New" %}</a>
       </div>
     </div>
   </div>

--- a/templates/organization/search.html
+++ b/templates/organization/search.html
@@ -6,7 +6,7 @@
     <div class="inner-title-wrapper">
       <h1 class="page-title">{% trans "Search an organization" %}</h1>
       <div class="pull-right">
-        <a href="/organization/add/" class="btn sfm-btn-action"><i class="fa fa-plus"></i> Add New</a>
+        <a href="/organization/add/" class="btn sfm-btn-action"><i class="fa fa-plus"></i> {% trans "Add New" %}{% trans "</" %}a>
       </div>
     </div>
   </div>
@@ -146,9 +146,9 @@
 
   <div class="row">
     <div class="col-sm-12 form-group">
-      <label for="people_srch_post"><span id="result-number"></span> Results
+      <label for="people_srch_post"><span id="result-number"></span> {% trans "Results" %}
         <div class="actions">
-          <button type="button" id="export-csv" class="btn sfm-btn-action">Export <i class="fa fa-share-square-o"></i></button>
+          <button type="button" id="export-csv" class="btn sfm-btn-action">{% trans "Export" %} <i class="fa fa-share-square-o"></i></button>
         </div>
       </label>
     </div>

--- a/templates/partials/back_skip_next.html
+++ b/templates/partials/back_skip_next.html
@@ -1,13 +1,15 @@
+{% load i18n %}
+
 <div class="row">
     <div class="form-group">
         <div class="col-md-12">
             <button type="submit" class="btn pull-right btn-info" value="Submit">
-            {% if has_next %} Next {% else %} Finish {% endif %}<i class="fa fa-fw fa-chevron-right"></i>
+            {% if has_next %} {% trans "Next" %} {% else %} {% trans "Finish" %} {% endif %}<i class="fa fa-fw fa-chevron-right"></i>
             </button>
             <div class="btn-group" role="group">
-                <a class="btn btn-info" href="{{ back_url }}"><i class="fa fa-fw fa-chevron-left"></i> Go back</a>
+                <a class="btn btn-info" href="{{ back_url }}"><i class="fa fa-fw fa-chevron-left"></i> {% trans "Go back" %}</a>
                 <a class="btn btn-info" href="{{ skip_url }}">
-                    Skip <i class="fa fa-chevron-right"></i><i class="fa fa-chevron-right"></i>
+                    {% trans "Skip" %} <i class="fa fa-chevron-right"></i><i class="fa fa-chevron-right"></i>
                 </a>
             </div>
         </div>

--- a/templates/partials/nav-wizard.html
+++ b/templates/partials/nav-wizard.html
@@ -1,10 +1,12 @@
+{% load i18n %}
+
 <div class="row">
         <ul class='nav nav-wizard'>
-            <li class='{% if "source" in request.path %} active {% endif %}'>1 - Create source</li>
-            <li class='{% if "organization" in request.path or "composition" in request.path %}{% if "geography" not in request.path %} active {% endif %}{% endif %}'>2 - Units</li>
-            <li class='{% if "person" in request.path and "membershipperson" not in request.path %} active {% endif %}'>3 - Personnel</li>
-            <li class='{% if "membershipperson" in request.path %} active {% endif %}'>4 - Positions</li>
-            <li class='{% if "geography" in request.path %} active {% endif %}'>5 - Geographies</li>
-            <li class='{% if "violation" in request.path %} active {% endif %}'>6 - Incidents</li>
+            <li class='{% if "source" in request.path %} active {% endif %}'>1 - {% trans "Create source" %}</li>
+            <li class='{% if "organization" in request.path or "composition" in request.path %}{% if "geography" not in request.path %} active {% endif %}{% endif %}'>2 - {% trans "Units" %}</li>
+            <li class='{% if "person" in request.path and "membershipperson" not in request.path %} active {% endif %}'>3 - {% trans "Personnel" %}</li>
+            <li class='{% if "membershipperson" in request.path %} active {% endif %}'>4 - {% trans "Positions" %}</li>
+            <li class='{% if "geography" in request.path %} active {% endif %}'>5 - {% trans "Geographies" %}</li>
+            <li class='{% if "violation" in request.path %} active {% endif %}'>6 - {% trans "Incidents" %}</li>
         </ul>
 </div>

--- a/templates/partials/organization_list_table.html
+++ b/templates/partials/organization_list_table.html
@@ -1,12 +1,13 @@
 {% load tablesort %}
 {% load countries %}
+{% load i18n %}
 
     <table class="table table-striped">
         <thead>
             <tr>
                 <th></th>
                 <th>
-                    Name
+                    {% trans "Name" %}
                     {% if sortable == 'True' %}
                     <a href="{% url 'list-organization' %}?{% query_transform request order_by='name' %}">
                         <i class="fa fa-sort"></i>
@@ -14,7 +15,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    Parent
+                    {% trans "Parent" %}
                     {% if sortable == 'True' %}
                     <a href="{% url 'list-organization' %}?{% query_transform request order_by='parent' %}">
                         <i class="fa fa-sort"></i>
@@ -22,7 +23,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    Classification
+                    {% trans "Classification" %}
                     {% if sortable == 'True' %}
                     <a href="{% url 'list-organization' %}?{% query_transform request order_by='classification' %}">
                         <i class="fa fa-sort"></i>
@@ -30,7 +31,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    Last site name
+                    {% trans "Last site name" %}
                     {% if sortable == 'True' %}
                     <a href="{% url 'list-organization' %}?{% query_transform request order_by='osmname' %}">
                         <i class="fa fa-sort"></i>
@@ -38,7 +39,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    Country
+                    {% trans "Country" %}
                 </th>
             </tr>
         </thead>

--- a/templates/partials/organization_merge.html
+++ b/templates/partials/organization_merge.html
@@ -1,8 +1,10 @@
-<h3>Organizations</h3>
+{% load i18n %}
+
+<h3>{% trans "Organizations" %}</h3>
 <form class="form" method="POST">
     {% csrf_token %}
     {% with canonical='True' sortable='False' object_list=objects %}
     {% include 'partials/organization_list_table.html' %}
     {% endwith %}
-    <button type="submit" class="btn btn-success">Save</button>
+    <button type="submit" class="btn btn-success">{% trans "Save" %}</button>
 </form>

--- a/templates/partials/organization_search_results.html
+++ b/templates/partials/organization_search_results.html
@@ -1,8 +1,10 @@
 {% load humanize %}
+{% load i18n %}
+
 <h3>
-    <strong><i class="fa fa-fw fa-users"></i> Units</strong>
-    <small>{{ hit_count|intcomma }} results</small>
-    <button class="pull-right btn btn-default merge" data-entity_type="organization">Merge selected</button>
+    <strong><i class="fa fa-fw fa-users"></i> {% trans "Units" %}</strong>
+    <small>{{ hit_count|intcomma }} {% trans "results" %}</small>
+    <button class="pull-right btn btn-default merge" data-entity_type="organization">{% trans "Merge selected" %}</button>
 </h3>
 
 {% with merge='True' object_list=objects sortable='False' %}

--- a/templates/partials/pagination.html
+++ b/templates/partials/pagination.html
@@ -1,17 +1,19 @@
+{% load i18n %}
+
 {% if page.has_previous or page.has_next %}
 <nav aria-label="Page navigation">
   <ul class="pagination">
     {% if page.has_previous %}
     <li>
         <a href="?{{ q_filters }}&amp;{{ page_type  }}_page={{ page.previous_page_number }}" aria-label="Previous">
-        <span aria-hidden="true">&laquo; Previous</span>
+        <span aria-hidden="true">&laquo; {% trans "Previous" %}</span>
       </a>
     </li>
     {% endif %}
     {% if page.has_next %}
     <li>
         <a href="?{{ q_filters }}&amp;{{ page_type }}_page={{ page.next_page_number }}" aria-label="Next">
-        <span aria-hidden="true">Next &raquo;</span>
+        <span aria-hidden="true">{% trans "Next" %} &raquo;</span>
       </a>
     </li>
     {% endif %}

--- a/templates/partials/person_list_table.html
+++ b/templates/partials/person_list_table.html
@@ -1,30 +1,32 @@
 {% load tablesort %}
+{% load i18n %}
     <table class="table table-striped">
         <thead>
             <tr>
                 {% if merge == 'True' %}
-                    <th>Select</th>
+                    <th>{% trans "Select" %}</th>
                 {% endif %}
                 {% if canonical == 'True' %}
-                    <th>Select canonical record</th>
+                    <th>{% trans "Select canonical record" %}</th>
                 {% endif %}
                 <th>
-                    Name
+                    {% trans "Name" %}
                     {% if sortable == 'True' %}
                     <a href="{% url 'list-person' %}?{% query_transform request order_by='name' %}">
                         <i class="fa fa-sort"></i>
                     </a>
                     {% endif %}
                 </th>
-                <th>Also known as</th>
-                <th>Most recent rank</th>
-                <th>Most recent unit</th>
-                <th>First citation</th>
-                <th>Last citation</th>
+                <th>{% trans "Also known as" %}</th>
+                <th>{% trans "Most recent rank" %}</th>
+                <th>{% trans "Most recent unit" %}</th>
+                <th>{% trans "First citation" %}</th>
+                <th>{% trans "Last citation" %}</th>
             </tr>
         </thead>
         <tbody>
             {% for object in object_list %}
+                <!-- Returns the object based on the language -->
                 {% if object.name.get_value %}
                     <tr>
                         {% if merge == 'True' %}

--- a/templates/partials/person_merge.html
+++ b/templates/partials/person_merge.html
@@ -1,8 +1,10 @@
-<h3>People</h3>
+{% load i18n %}
+
+<h3>{% trans "People" %}</h3>
 <form class="form" method="POST">
     {% csrf_token %}
     {% with canonical='True' object_list=objects %}
         {% include 'partials/person_list_table.html' %}
     {% endwith %}
-    <button type="submit" class="btn btn-success">Save</button>
+    <button type="submit" class="btn btn-success">{% trans "Save" %}</button>
 </form>

--- a/templates/partials/person_search_results.html
+++ b/templates/partials/person_search_results.html
@@ -1,8 +1,10 @@
+{% load i18n %}
 {% load humanize %}
+
 <h3>
-    <strong><i class="fa fa-fw fa-user"></i> Personnel</strong>
-    <small>{{ hit_count|intcomma }} results</small>
-    <button class="pull-right btn btn-default merge" data-entity_type="person">Merge selected</button>
+    <strong><i class="fa fa-fw fa-user"></i> {% trans "Personnel" %}</strong>
+    <small>{{ hit_count|intcomma }} {% trans "results" %}</small>
+    <button class="pull-right btn btn-default merge" data-entity_type="person">{% trans "Merge selected" %}</button>
 </h3>
 
 {% with merge='True' object_list=objects %}

--- a/templates/partials/source_search_results.html
+++ b/templates/partials/source_search_results.html
@@ -1,11 +1,13 @@
-<h3>Sources</h3>
+{% load i18n %}
+
+<h3>{% trans "Sources" %}</h3>
 <table class="table table-condensed">
     <thead>
         <tr>
-            <th>Title</th>
-            <th>Publication date</th>
-            <th>Publication</th>
-            <th>Publication country</th>
+            <th>{% trans "Title" %}</th>
+            <th>{% trans "Publication date" %}</th>
+            <th>{% trans "Publication" %}</th>
+            <th>{% trans "Publication country" %}</th>
         </tr>
     </thead>
     <tbody>

--- a/templates/partials/version_list.html
+++ b/templates/partials/version_list.html
@@ -1,8 +1,10 @@
+{% load i18n %}
+
 <div class="row">
     <div class="col-sm-12">
-        <h3 id="changelog"><i class="fa fa-fw fa-refresh"></i> Changelog</h3>
+        <h3 id="changelog"><i class="fa fa-fw fa-refresh"></i> {% trans "Changelog" %}</h3>
         <hr />
-        <p>Select an attribute below to review the changes our staff have made to this entity.</p>
+        <p>{% trans "Select an attribute below to review the changes our staff have made to this entity." %}</p>
         {% for version in versions %}
             {% for type_name, type_group in version.items %}
                 {% if type_group|last|last|length > 0 %} {# Only create tables for groups containing revisions #}
@@ -16,11 +18,11 @@
                         <div class="panel-body collapse" id="show-{{type_name|slugify}}">
                             <table class="table table-condensed">
                                 <thead>
-                                    <th>Value</th>
-                                    <th>Confidence</th>
-                                    <th>Date created</th>
-                                    <th>User</th>
-                                    <th>Sources</th>
+                                    <th>{% trans "Value" %}</th>
+                                    <th>{% trans "Confidence" %}</th>
+                                    <th>{% trans "Date created" %}</th>
+                                    <th>{% trans "User" %}</th>
+                                    <th>{% trans "Sources" %}</th>
                                 </thead>
                                 <tbody>
                     {% endif %}

--- a/templates/partials/violation_description.html
+++ b/templates/partials/violation_description.html
@@ -1,8 +1,10 @@
+{% load i18n %}
+
 <div id="description-content-{{ N }}" class="collapse description-text">
     <p>{{ description }}</p>
 </div>
 <a href="#description-content-{{ N }}" data-toggle="collapse" class="collapsed">
-    <span class="text-danger show-more">Show more <i class="fa fa-fw fa-arrow-down"></i></span>
-    <span class="text-danger show-less">Show less <i class="fa fa-fw fa-arrow-up"></i></span>
+    <span class="text-danger show-more">{% trans "Show more" %} <i class="fa fa-fw fa-arrow-down"></i></span>
+    <span class="text-danger show-less">{% trans "Show less" %} <i class="fa fa-fw fa-arrow-up"></i></span>
 </a>
 

--- a/templates/partials/violation_list_table.html
+++ b/templates/partials/violation_list_table.html
@@ -1,12 +1,13 @@
 {% load tablesort %}
 {% load countries %}
 {% load facets %}
+{% load i18n %}
 
     <table class="table table-striped">
         <thead>
             <tr>
                 <th>
-                    Start Date
+                    {% trans "Start Date" %}
                     {% if sortable == 'True' %}
                     <a href="{% url 'list-violation' %}?{% query_transform request order_by='start_date' %}">
                         <i class="fa fa-sort"></i>
@@ -14,26 +15,26 @@
                     {% endif %}
                 </th>
                 <th>
-                    End Date
+                    {% trans "End Date" %}
                     {% if sortable == 'True' %}
                     <a href="{% url 'list-violation' %}?{% query_transform request order_by='end_date' %}">
                         <i class="fa fa-sort"></i>
                     </a>
                     {% endif %}
                 </th>
-                <th>Description</th>
-                <th>Violation types</th>
+                <th>{% trans "Description" %}</th>
+                <th>{% trans "Violation types" %}</th>
                 <th>
-                    Location
+                    {% trans "Location" %}
                     {% if sortable == 'True' %}
                     <a href="{% url 'list-violation' %}?{% query_transform request order_by='location' %}">
                         <i class="fa fa-sort"></i>
                     </a>
                     {% endif %}
                 </th>
-                <th>Perpetrators</th>
+                <th>{% trans "Perpetrators" %}</th>
                 <th>
-                    Perpetrator classification
+                    {% trans "Perpetrator classification" %}
                     {% if sortable == 'True' %}
                     <a href="{% url 'list-violation' %}?{% query_transform request order_by='classification' %}">
                         <i class="fa fa-sort"></i>
@@ -63,7 +64,7 @@
                         {% if object.description.get_value %}
                             {{ object.description.get_value|truncatewords:25 }}
                         {% else %}
-                            View Detail
+                            {% trans "View Detail" %}
                         {% endif %}
                         </a>
                     </td>

--- a/templates/partials/violation_search_results.html
+++ b/templates/partials/violation_search_results.html
@@ -1,7 +1,9 @@
+{% load i18n %}
+
 {% load humanize %}
 <h3>
-    <strong><i class="fa fa-fw fa-exclamation-triangle"></i> Incidents</strong>
-    <small>{{ hit_count|intcomma }} results</small>
+    <strong><i class="fa fa-fw fa-exclamation-triangle"></i> {% trans "Incidents" %}</strong>
+    <small>{{ hit_count|intcomma }} {% trans "results" %}</small>
 </h3>
 
 {% with object_list=objects %}

--- a/templates/person/create.html
+++ b/templates/person/create.html
@@ -12,8 +12,8 @@
 {% block content %}
 {% include 'partials/nav-wizard.html' %}
 <div class="row">
-    <h2><i class="fa fa-fw fa-user"></i> Personnel</h2>
-    <p>Describe any personnel found in <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{ source.published_on|date:"F d, Y"}})</p>
+    <h2><i class="fa fa-fw fa-user"></i>{% trans "Personnel" %}</h2>
+    <p>{% trans "Describe any personnel found in" %} <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{ source.published_on|date:"F d, Y"}})</p>
     <hr />
 </div>
 <form method="post" action="" class="form-horizontal" id="person-form">
@@ -31,7 +31,7 @@
                         {% else %}
                             <div class="form-group">
                         {% endif %}
-                            <label class="col-sm-2 control-label">Name</label>
+                            <label class="col-sm-2 control-label">{% trans "Name" %}</label>
                             <div class="col-sm-8">
                                 <select id="id_form-{{ form_id }}-name" class="form-control name-field" name="form-{{ form_id }}-name">
                                     {% if form.cleaned_data.name %}
@@ -51,7 +51,7 @@
                         {% else %}
                             <div class="form-group">
                         {% endif %}
-                            <label class="col-sm-2 control-label">Aliases</label>
+                            <label class="col-sm-2 control-label">{% trans "Aliases" %}</label>
                             <div class="col-sm-8">
                                 <select id="id_form-{{ form_id }}-alias" class="form-control alias-field" name="form-{{ form_id }}-alias" multiple="multiple">
                                 </select>
@@ -67,7 +67,7 @@
                         {% else %}
                             <div class="form-group">
                         {% endif %}
-                            <label class="col-sm-2 control-label">Division identifier</label>
+                            <label class="col-sm-2 control-label">{% trans "Division identifier" %}</label>
                             <div class="col-sm-8">
                                 <select id="id_form-{{ form_id }}-division_id" class="form-control division-field" name="form-{{ form_id }}-division_id">
                                     {% if form.cleaned_data.division_id %}
@@ -89,7 +89,7 @@
                     {% else %}
                         <div class="form-group">
                     {% endif %}
-                    <label class="col-sm-2 control-label" for="id_form-{{ form_id }}-orgs">Member units</label>
+                    <label class="col-sm-2 control-label" for="id_form-{{ form_id }}-orgs">{% trans "Member units" %}</label>
                     <div class="col-sm-8">
                         <select id="id_form-{{ form_id }}-orgs" class="form-control orgs-field" name="form-{{ form_id }}-orgs" multiple="multiple">
                                 {% for organization in organizations %}
@@ -97,7 +97,7 @@
                                 {% endfor %}
                             </select>
                                 {% if form.orgs.errors %}
-                                    <span class="help-block"><i class="fa fa-remove"> </i> A person must belong to at least one unit.</span>
+                                    <span class="help-block"><i class="fa fa-remove"> </i> {% trans "A person must belong to at least one unit." %}</span>
                                 {% endif %}
                         </div>
                         </div>
@@ -108,7 +108,7 @@
                             <div classs="form-group">
                                 <div class="col-sm-12">
                                     <button id="remove_form-{{ form_id }}" href="javascript://" class="remove-form btn btn-danger">
-                                        Remove Person <i class="fa fa-minus"></i>
+                                        {% trans "Remove Person" %} <i class="fa fa-minus"></i>
                                     </button>
                                 </div>
                             </div>
@@ -124,7 +124,7 @@
 <div class="row">
     <div class="col-sm-12">
         <button class="btn btn-link" type="button" id="add-form">
-            <i class="fa fa-fw fa-plus-circle"></i> Add another person
+            <i class="fa fa-fw fa-plus-circle"></i> {% trans "Add another person" %}
         </button>
     </div>
 </div>
@@ -143,7 +143,7 @@
 <script type="text/EJS" id="formTemplate">
     <div id="form-<%= form_id %>-wrapper">
         <div class="form-group">
-            <label class="col-sm-2 control-label">Name</label>
+            <label class="col-sm-2 control-label">{% trans "Name" %}</label>
             <div class="col-sm-8">
                 <select id="id_form-<%= form_id %>-name" class="form-control name-field" name="form-<%= form_id %>-name">
                 </select>
@@ -151,21 +151,21 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="col-sm-2 control-label">Aliases</label>
+            <label class="col-sm-2 control-label">{% trans "Aliases" %}</label>
             <div class="col-sm-8">
                 <select id="id_form-<%= form_id %>-alias" class="form-control" name="form-<%= form_id %>-alias" multiple="multiple">
                 </select>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-sm-2 control-label">Division identifier</label>
+            <label class="col-sm-2 control-label">{% trans "Division identifier" %}</label>
             <div class="col-sm-8">
                 <select id="id_form-<%= form_id %>-division_id" class="form-control division-field" name="form-<%= form_id %>-division_id">
                 </select>
             </div>
         </div>
         <div class="form-group">
-            <label class="col-sm-2 control-label" for="id_form-<%= form_id %>-orgs">Member units</label>
+            <label class="col-sm-2 control-label" for="id_form-<%= form_id %>-orgs">{% trans "Member units" %}</label>
             <div class="col-sm-8">
                 <select id="id_form-<%= form_id %>-orgs" class="form-control orgs-field" name="form-<%= form_id %>-orgs" multiple="multiple">
                     {% for organization in organizations %}
@@ -180,7 +180,7 @@
             <div classs="form-group">
                 <div class="col-sm-10 col-sm-offset-2">
                     <button id="remove_form-<%= form_id %>" type="button" class="remove-form btn btn-link">
-                        <i class="fa fa-fw fa-times"></i> Remove this person
+                        <i class="fa fa-fw fa-times"></i> {% trans "Remove this person" %}
                     </button>
                 </div>
             </div>

--- a/templates/person/detail.html
+++ b/templates/person/detail.html
@@ -7,11 +7,11 @@
     <h1 class="page-title">
         <i class="fa fa-fw fa-user"></i> {{ person.name.get_value }}
         <small>
-            <a href="{% url 'edit-person' person.id %}" class="btn btn-default">Edit</a>
+            <a href="{% url 'edit-person' person.id %}" class="btn btn-default">{% trans "Edit" %}</a>
         </small>
     </h1>
     {% if person.aliases.get_list %}
-        <p>Also known as:
+        <p>{% trans "Also known as:" %}
             {% for alias in person.aliases.get_list %}
             <strong>{{ alias.get_value }}{% if not forloop.last %}|{% endif %} </strong>
             {% endfor %}
@@ -21,24 +21,24 @@
 
 {% block sidebar %}
     {% has_versions person as changelog %}
-    {% if last_seen_as %}<li><a href="#last-seen-as"><i class="fa fa-fw fa-clock-o"></i> Last seen as</a></li>{% endif %}
-    {% if memberships %}<li><a href="#memberships"><i class="fa fa-fw fa-users"></i> Memberships</a></li>{% endif %}
-    {% if chain_of_command %}<li><a href="#chain-of-command"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> Chain of command</a></li>{% endif %}
-    {% if subordinates %}<li><a href="#subordinates"><i class="fa fa-fw fa-share-alt fa-rotate-90"></i> Subordinates</a></li>{% endif %}
-    {% if sources %}<li><a href="#sources"><i class="fa fa-fw fa-files-o"></i> Sources</a></li>{% endif %}
-    {% if changelog %}<li><a href="#changelog"><i class="fa fa-fw fa-refresh"></i> Changelog</a></li>{% endif %}
+    {% if last_seen_as %}<li><a href="#last-seen-as"><i class="fa fa-fw fa-clock-o"></i> {% trans "Last seen as" %}</a></li>{% endif %}
+    {% if memberships %}<li><a href="#memberships"><i class="fa fa-fw fa-users"></i> {% trans "Memberships" %}</a></li>{% endif %}
+    {% if chain_of_command %}<li><a href="#chain-of-command"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> {% trans "Chain of command" %}</a></li>{% endif %}
+    {% if subordinates %}<li><a href="#subordinates"><i class="fa fa-fw fa-share-alt fa-rotate-90"></i> {% trans "Subordinates" %}</a></li>{% endif %}
+    {% if sources %}<li><a href="#sources"><i class="fa fa-fw fa-files-o"></i> {% trans "Sources" %}</a></li>{% endif %}
+    {% if changelog %}<li><a href="#changelog"><i class="fa fa-fw fa-refresh"></i> {% trans "Changelog" %}</a></li>{% endif %}
 {% endblock %}
 
 {# This is exactly the same as the previous sidebar #}
 {# Django just won't let you reuse blocks w/o 3rd party plugins :( #}
 {% block sidebar_mobile %}
     {% has_versions person as changelog %}
-    {% if last_seen_as %}<li><a href="#last-seen-as"><i class="fa fa-fw fa-clock-o"></i> Last seen as</a></li>{% endif %}
-    {% if memberships %}<li><a href="#memberships"><i class="fa fa-fw fa-users"></i> Memberships</a></li>{% endif %}
-    {% if chain_of_command %}<li><a href="#chain-of-command"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> Chain of command</a></li>{% endif %}
-    {% if subordinates %}<li><a href="#subordinates"><i class="fa fa-fw fa-share-alt fa-rotate-90"></i> Subordinates</a></li>{% endif %}
-    {% if sources %}<li><a href="#sources"><i class="fa fa-fw fa-files-o"></i> Sources</a></li>{% endif %}
-    {% if changelog %}<li><a href="#changelog"><i class="fa fa-fw fa-refresh"></i> Changelog</a></li>{% endif %}
+    {% if last_seen_as %}<li><a href="#last-seen-as"><i class="fa fa-fw fa-clock-o"></i> {% trans "Last seen as" %}</a></li>{% endif %}
+    {% if memberships %}<li><a href="#memberships"><i class="fa fa-fw fa-users"></i> {% trans "Memberships" %}</a></li>{% endif %}
+    {% if chain_of_command %}<li><a href="#chain-of-command"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> {% trans "Chain of command" %}</a></li>{% endif %}
+    {% if subordinates %}<li><a href="#subordinates"><i class="fa fa-fw fa-share-alt fa-rotate-90"></i> {% trans "Subordinates" %}</a></li>{% endif %}
+    {% if sources %}<li><a href="#sources"><i class="fa fa-fw fa-files-o"></i> {% trans "Sources" %}</a></li>{% endif %}
+    {% if changelog %}<li><a href="#changelog"><i class="fa fa-fw fa-refresh"></i> {% trans "Changelog" %}</a></li>{% endif %}
 {% endblock %}
 
 {% block details %}
@@ -46,7 +46,7 @@
     {% if last_seen_as %}
     <div class="row">
         <div class="col-sm-12">
-            <h3 id="last-seen-as"><i class="fa fa-fw fa-clock-o"></i> Last seen as</h3>
+            <h3 id="last-seen-as"><i class="fa fa-fw fa-clock-o"></i> {% trans "Last seen as" %}</h3>
             <p>{{ last_seen_as|safe }}</p>
         </div>
     </div>
@@ -55,17 +55,17 @@
     {% if memberships %}
     <div class="row">
         <div class="col-sm-12">
-            <h3 id="memberships"><i class="fa fa-fw fa-users"></i> Memberships</h3>
+            <h3 id="memberships"><i class="fa fa-fw fa-users"></i> {% trans "Memberships" %}</h3>
             <hr />
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>Organization</th>
-                        <th>Rank</th>
-                        <th>Role</th>
-                        <th>Title</th>
-                        <th>Start date</th>
-                        <th>End date</th>
+                        <th>{% trans "Organization" %}</th>
+                        <th>{% trans "Rank" %}</th>
+                        <th>{% trans "Role" %}</th>
+                        <th>{% trans "Title" %}</th>
+                        <th>{% trans "Start date" %}</th>
+                        <th>{% trans "End date" %}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -92,7 +92,7 @@
     {% if chain_of_command %}
     <div class="row">
         <div class="col-sm-12">
-            <h3 id="chain-of-command"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> Chain of command</h3>
+            <h3 id="chain-of-command"><i class="fa fa-fw fa-sitemap fa-rotate-180"></i> {% trans "Chain of command" %}</h3>
             <hr />
             <div id="org-chart-container" class="org-chart-container"></div>
         </div>
@@ -102,19 +102,19 @@
     {% if subordinates %}
     <div class="row">
         <div class="col-sm-12">
-            <h3 id="subordinates"><i class="fa fa-fw fa-share-alt fa-rotate-90"></i> Subordinates</h3>
-            <small>Commanders of units that were subordinate to any units commanded by this person</small>
+            <h3 id="subordinates"><i class="fa fa-fw fa-share-alt fa-rotate-90"></i> {% trans "Subordinates" %}</h3>
+            <small>{% trans "Commanders of units that were subordinate to any units commanded by this person" %}</small>
             <hr />
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Rank</th>
-                        <th>Role</th>
-                        <th>Unit</th>
-                        <th>Start of overlap</th>
-                        <th>End of overlap</th>
-                        <th>Duration of overlap</th>
+                        <th>{% trans "Name" %}</th>
+                        <th>{% trans "Rank" %}</th>
+                        <th>{% trans "Role" %}</th>
+                        <th>{% trans "Unit" %}</th>
+                        <th>{% trans "Start of overlap" %}</th>
+                        <th>{% trans "End of overlap" %}</th>
+                        <th>{% trans "Duration of overlap" %}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -146,7 +146,7 @@
     {% if events %}
     <div class="row">
         <div class="col-sm-12">
-            <h3>Events</h3>
+            <h3>{% trans "Events" %}</h3>
             <hr />
             {% for event in events %}
                 <div class="row">

--- a/templates/person/edit.html
+++ b/templates/person/edit.html
@@ -11,7 +11,7 @@
     {% else %}
         <div class="form-group">
     {% endif %}
-        <label class="col-sm-2 control-label">Person name</label>
+        <label class="col-sm-2 control-label">{% trans "Person name" %}</label>
         <div class="col-sm-8">
             <select id="id_name" class="form-control" name="name">
                     <option value="" selected="selected">--------</option>
@@ -32,7 +32,7 @@
     {% else %}
         <div class="form-group">
     {% endif %}
-        <label class="col-sm-2 control-label">Aliases</label>
+        <label class="col-sm-2 control-label">{% trans "Aliases" %}</label>
         <div class="col-sm-8">
             <select id="id_alias" class="form-control" name="alias" multiple="multiple">
                 {% for alias in form_data.aliases %}
@@ -51,7 +51,7 @@
     {% else %}
         <div class="form-group">
     {% endif %}
-        <label class="col-sm-2 control-label">Division identifier</label>
+        <label class="col-sm-2 control-label">{% trans "Division identifier" %}</label>
         <div class="col-sm-8">
             <select id="id_division_id" class="form-control division-field" name="division_id">
                     <option value="" selected="selected">--------</option>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -1,31 +1,32 @@
+{% load i18n %}
 {% load menu %}
 <aside>
   <a href="/"><div class="sidebar-title"></div></a>
 
   <nav>
     <ul>
-      <li class="{% active "person"%}"><a href="/person/">People </a></li>
-      <li class="{% active "/membershipperson" %}"><a href="/membershipperson/">Person Membership</a></li>
-      <li class="{% active "/organization" %}"><a href="/organization/">Organization</a></li>
-      <li class="{% active "/composition" %}"><a href="/composition/">Composition</a></li>
-      <li class="{% active "/association" %}"><a href="/association/">Association</a></li>
-      <li class="{% active "/area" %}"><a href="/area/">Area</a></li>
-      <li class="{% active "/emplacement" %}"><a href="/emplacement/">Emplacement</a></li>
-      <li class="{% active "/geosite" %}"><a href="/geosite/">Site</a></li>
-      <li class="{% active "/violation" %}"><a href="/violation/">Violation</a></li>
+      <li class="{% active "person"%}"><a href="/person/">{% trans "People" %}</a></li>
+      <li class="{% active "/membershipperson" %}"><a href="/membershipperson/">{% trans "Person Membership" %}</a></li>
+      <li class="{% active "/organization" %}"><a href="/organization/">{% trans "Organization" %}</a></li>
+      <li class="{% active "/composition" %}"><a href="/composition/">{% trans "Composition" %}</a></li>
+      <li class="{% active "/association" %}"><a href="/association/">{% trans "Association" %}</a></li>
+      <li class="{% active "/area" %}"><a href="/area/">{% trans "Area" %}</a></li>
+      <li class="{% active "/emplacement" %}"><a href="/emplacement/">{% trans "Emplacement" %}</a></li>
+      <li class="{% active "/geosite" %}"><a href="/geosite/">{% trans "Site" %}</a></li>
+      <li class="{% active "/violation" %}"><a href="/violation/">{% trans "Violation" %}</a></li>
     </ul>
   </nav>
   <ul class="bottom-list">
     <li>
       <a href="#">
         <i class="fa fa-power-off"></i>
-        <a href="/logout">Log Out</a>
+        <a href="/logout">{% trans "Log Out" %}</a>
       </a>
     </li>
     <li>
       <a href="#">
         <i class="fa fa-cog"></i>
-        Settings
+        {% trans "Settings" %}
       </a>
     </li>
   </ul>

--- a/templates/violation/detail.html
+++ b/templates/violation/detail.html
@@ -196,8 +196,8 @@
         <script src="https://npmcdn.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
         <script type="text/javascript">
             $(document).ready(function(){
-                var center_x = {{ location.x }};
-                var center_y = {{ location.y }};
+                var center_x = {{ location.x|safe }};
+                var center_y = {{ location.y|safe }};
                 var map = L.map('geoname_map').setView([center_y, center_x], 10);
                 var attribution = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>';
                 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',


### PR DESCRIPTION
@jeancochrane - this pull request wraps template text inside "trans" tags. It contains many, many lines of code, but is also fairly redundant. Please let me know if you see something funny, e.g., a missing "trans", but the use of a {% %} block.