### PR TITLE
Login fix

### DIFF
--- a/sfm_pc/settings.py
+++ b/sfm_pc/settings.py
@@ -198,6 +198,7 @@ LOGIN_URL = reverse_lazy('account_login')
 LOGIN_REDIRECT_URL = '/'
 
 AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
     'allauth.account.auth_backends.AuthenticationBackend',
 )
 


### PR DESCRIPTION
A user that is created in the Django admin has trouble logging in sometimes. My suspicion is that this is because the default Django authentication backend was turned off. This PR turns it back on.