### PR TITLE
Search for OSM features by ID on the geography create page

### DIFF
--- a/sfm_pc/views.py
+++ b/sfm_pc/views.py
@@ -301,6 +301,10 @@ def osm_autocomplete(request):
     '''
 
     if search_by_id:
+        # We want to search for text that begins with the query term, which uses
+        # SQL "string%" wildcard syntax. But because of the Django DB API's
+        # particular string formatting idiosyncracies, we need to append the %
+        # directly to the search term before formatting it into the query.
         q_args[0] += '%%'
         query = "{} WHERE id::text LIKE %s".format(query)
     else:

--- a/templates/organization/create-geography.html
+++ b/templates/organization/create-geography.html
@@ -15,8 +15,7 @@
     <h2><i class="fa fa-fw fa-map-marker"></i> {% trans "Geographies" %}</h2>
     <p>{% trans "Describe any geographies related to organizations found in" %} <strong>{{ source.title }}</strong> ({{source.publication.title}}, {{ source.published_on|date:"F d, Y"}})</p>
     <hr />
-</div>                                    
-                    
+</div>
 <form method="post" action="" class="form-horizontal">
     {% csrf_token %}
     {{ formset.management_form }}
@@ -191,7 +190,7 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="control-label col-sm-2" for="id_form-<%= form_id %>-osmname">{% trans "OSM Name" %}</label>
+            <label class="control-label col-sm-2" for="id_form-<%= form_id %>-osmname">{% trans "OSM ID" %}</label>
             <div class="col-sm-8">
                 <select class="form-control" id="id_form-<%= form_id %>-osm_id" name="form-<%= form_id %>-osm_id"></select>
                 <input type="hidden" name="form-<%= form_id %>-osm_id_text" id="id_form-<%= form_id %>-osm_id_text" />
@@ -257,7 +256,10 @@ var osm_opts = {
                 geo_type = 'boundary';
             }
 
-            var qparams = {q: params.term}
+            var qparams = {
+                q: params.term,
+                search_by_id: 'true'
+            }
 
             if (geo_type){
                 qparams['geo_type'] = geo_type;


### PR DESCRIPTION
Creates an optional `search_by_id` parameter to the `osm-autocomplete` endpoint that changes the search on the `osm_data` table to use OSM IDs instead of full-text indexed search. 

Closes #216.