### PR TITLE
Make returning versions consistent

### DIFF
--- a/organization/models.py
+++ b/organization/models.py
@@ -11,8 +11,9 @@ from complex_fields.models import ComplexField, ComplexFieldContainer, ComplexFi
 from complex_fields.base_models import BaseModel
 from django_date_extensions.fields import ApproximateDateField
 
+from sfm_pc.utils import VersionsMixin
 
-class Organization(models.Model, BaseModel):
+class Organization(models.Model, BaseModel, VersionsMixin):
 
     uuid = models.UUIDField(default=uuid.uuid4,
                             editable=False,

--- a/person/models.py
+++ b/person/models.py
@@ -18,7 +18,7 @@ from complex_fields.models import ComplexField, ComplexFieldContainer, \
     ComplexFieldListContainer
 from complex_fields.base_models import BaseModel
 
-from sfm_pc.utils import ComplexVersionsMixin
+from sfm_pc.utils import VersionsMixin
 
 
 VERSION_RELATED_FIELDS = [
@@ -31,7 +31,7 @@ VERSION_RELATED_FIELDS = [
 
 
 @reversion.register(follow=VERSION_RELATED_FIELDS)
-class Person(models.Model, BaseModel, ComplexVersionsMixin):
+class Person(models.Model, BaseModel, VersionsMixin):
 
     uuid = models.UUIDField(default=uuid.uuid4,
                             editable=False,

--- a/sfm_pc/settings.py
+++ b/sfm_pc/settings.py
@@ -40,6 +40,12 @@ except ImportError:
     RAVEN_CONFIG = {}
 
 try:
+    from .settings_local import EXTRA_DEBUG_TOOLBAR_PANELS
+except ImportError:
+    EXTRA_DEBUG_TOOLBAR_PANELS = []
+
+
+try:
     from .settings_local import DATABASE_URL, GOOGLE_MAPS_KEY, \
         SECRET_KEY, DEBUG, ALLOWED_HOSTS, IMPORTER_USER, SOLR_URL, \
         CACHES
@@ -110,6 +116,22 @@ MIDDLEWARE_CLASSES = (
 
 # Debug toolbar middleware needs to be included as early as possible
 MIDDLEWARE_CLASSES = EXTRA_MIDDLEWARE_CLASSES + MIDDLEWARE_CLASSES
+
+DEBUG_TOOLBAR_PANELS = [
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.settings.SettingsPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+    'debug_toolbar.panels.templates.TemplatesPanel',
+    'debug_toolbar.panels.cache.CachePanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.logging.LoggingPanel',
+    'debug_toolbar.panels.redirects.RedirectsPanel',
+] + EXTRA_DEBUG_TOOLBAR_PANELS
+
 
 ROOT_URLCONF = 'sfm_pc.urls'
 

--- a/sfm_pc/utils.py
+++ b/sfm_pc/utils.py
@@ -365,24 +365,6 @@ class VersionsMixin(object):
         return differences
 
 
-class ComplexVersionsMixin(object):
-    '''
-    Model mixin for models related to ComplexFields to get a unified snapshot of
-    a given change to all fields of a parent model
-    '''
-
-    def getVersions(self):
-        versions = Version.objects.get_for_object(self)
-
-        serialized = []
-
-        for version in versions:
-            for revision in version.revision.version_set.all():
-                serialized.append(revision.serialized_data)
-
-        return serialized
-
-
 def execute_sql(file_path):
     '''
     Execute arbitrary SQL code from a file location.

--- a/violation/models.py
+++ b/violation/models.py
@@ -14,10 +14,12 @@ from source.models import Source
 from person.models import Person
 from organization.models import Organization
 from geosite.models import Geosite
+from sfm_pc.utils import VersionsMixin
 
-class Violation(models.Model, BaseModel):
-    uuid = models.UUIDField(default=uuid.uuid4, 
-                            editable=False, 
+
+class Violation(models.Model, BaseModel, VersionsMixin):
+    uuid = models.UUIDField(default=uuid.uuid4,
+                            editable=False,
                             db_index=True)
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Make sure that we are only using one way to display version information.