### PR TITLE
Use Solr to build org charts

### DIFF
--- a/person/views.py
+++ b/person/views.py
@@ -122,7 +122,6 @@ def get_commanders(mem_start, mem_end, compositions, relationship='child'):
 
     # Get start and end date for this membership, to determine
     # overlap
-    # mem_start = membership.firstciteddate.get_value()
     no_start = False
     if mem_start is None:
         # Make a bogus date that everything will be greater than
@@ -131,7 +130,6 @@ def get_commanders(mem_start, mem_end, compositions, relationship='child'):
     else:
         mem_start = repr(mem_start.value)
 
-    # mem_end = membership.lastciteddate.get_value()
     no_end = False
     if mem_end is None:
         mem_end = date.today()

--- a/sfm_pc/utils.py
+++ b/sfm_pc/utils.py
@@ -7,6 +7,8 @@ from io import StringIO, BytesIO
 import zipfile
 import csv
 
+import pysolr
+
 from reversion.models import Version
 
 from django.conf import settings
@@ -507,101 +509,32 @@ def generate_hierarchy(query, q_args, rel_field, sources=False):
     return hierarchy
 
 # this makes an edge list that shows the parent relationships (see child_id)
+# TODO: http://127.0.0.1:8984/solr/sfm/query?q=*:*&fq={!graph+from=id+to=organization_parent_id_ss_fct%20returnRoot=true}id:d0ed3220-ba9f-40d2-8e4e-cbdde66e7178&fl=organization_name_s
+
+solr = pysolr.Solr(settings.SOLR_URL)
+
+
 def get_org_hierarchy_by_id(org_id, when=None, sources=False):
     '''
     org_id: uuid for the organization
-    date: date for limiting the search
-    '''
-    hierarchy = '''
-        WITH RECURSIVE children AS (
-          SELECT
-            o.*,
-            NULL::VARCHAR AS org_org_id,
-            NULL::VARCHAR AS child_id,
-            NULL::VARCHAR AS child_name,
-            NULL::VARCHAR AS start_date,
-            NULL::VARCHAR AS end_date,
-            NULL::VARCHAR AS comp_open_ended,
-            NULL::VARCHAR AS source,
-            NULL::VARCHAR AS confidence,
-            NULL::VARCHAR AS commander,
-            NULL::VARCHAR AS relationship_classification
-          FROM organization As o
-          WHERE id = %s
-          UNION
-          SELECT
-            o.*,
-            org_org.id::VARCHAR as org_org_id,
-            h.child_id::VARCHAR AS child_id,
-            children.name AS child_name,
-            h.start_date::VARCHAR,
-            h.end_date::VARCHAR,
-            h.open_ended AS comp_open_ended,
-            row_to_json(ss.*)::VARCHAR AS source,
-            ccc.confidence,
-            person.name,
-            h.classification AS relationship_classification
-          FROM organization AS o
-          JOIN organization_organization as org_org
-            on o.id = org_org.uuid
-          JOIN composition AS h
-            ON o.id = h.parent_id
-          JOIN composition_compositionparent AS ccc
-            ON h.id = ccc.object_ref_id
-          LEFT JOIN composition_compositionparent_sources AS cccs
-            ON ccc.id = cccs.compositionparent_id
-          LEFT JOIN source_source AS ss
-            ON cccs.source_id = ss.uuid
-          LEFT JOIN membershipperson AS mem
-            ON o.id = mem.organization_id
-          LEFT JOIN person
-            ON person.id = mem.member_id
-          JOIN children
-            ON children.id = h.child_id
-        ) SELECT *
-          FROM children
-          WHERE id != %s
-          AND relationship_classification = 'Command'
+    when: date for limiting the search
     '''
 
-    q_args = [org_id, org_id]
+    base_url = settings.SOLR_URL
+
+    filter_query = '{!graph from=id'
+    filter_query += 'to=organization_parent_id_ss_fct returnRoot=true}'
+    filter_query += 'id:{0}'.format(org_id)
+
     if when:
-        hierarchy = '''
-            {hierarchy}
-            AND CASE
-              WHEN (start_date IS NOT NULL AND
-                    end_date IS NOT NULL AND
-                    comp_open_ended IN ('N', 'E'))
-              THEN (%s BETWEEN start_date AND end_date)
-              WHEN (start_date IS NOT NULL AND
-                    end_date IS NOT NULL AND
-                    comp_open_ended = 'Y')
-              THEN (%s BETWEEN start_date AND NOW()::date::varchar)
-              WHEN (start_date IS NOT NULL AND
-                    end_date IS NULL AND
-                    comp_open_ended IN ('N', 'E'))
-              THEN (start_date = %s)
-              WHEN (start_date IS NOT NULL AND
-                    end_date IS NULL AND
-                    comp_open_ended = 'Y')
-              THEN (%s BETWEEN start_date AND NOW()::date::varchar)
-              WHEN (start_date IS NULL AND
-                    end_date IS NOT NULL AND
-                    comp_open_ended IN ('N', 'E'))
-              THEN (end_date = %s)
-              WHEN (start_date IS NULL AND
-                    end_date IS NOT NULL AND
-                    comp_open_ended = 'Y')
-              THEN TRUE
-            END
-        '''.format(hierarchy=hierarchy, when=when)
-        q_args.extend([when] * 5)
+        filter_query += ' AND {!field f=organization_parent_daterange_drs op=contains}%s' % when
 
-    hierarchy = '{} ORDER BY id'.format(hierarchy)
+    results = solr.search('*:*', fq=filter_query)
 
-    hierarchy = generate_hierarchy(hierarchy, q_args, 'child_id', sources=sources)
+    import pdb
+    pdb.set_trace()
 
-    return hierarchy
+    return [r for r in results]
 
 def get_child_orgs_by_id(org_id, when=None, sources=False):
     hierarchy = '''

--- a/sfm_pc/views.py
+++ b/sfm_pc/views.py
@@ -341,17 +341,17 @@ def command_chain(request, org_id='', when=None, parents=True):
     # Add hierarchy to nodelist and edgelist
     if parents:
         hierarchy_list = get_org_hierarchy_by_id(org_id, when=when)
-        from_key, to_key = 'id', 'child_id'
+        from_key, to_key = 'organization_parent_id_ss', 'id'
     else:
         hierarchy_list = get_child_orgs_by_id(org_id, when=when)
-        from_key, to_key = 'parent_id', 'id'
+        from_key, to_key = 'id', 'organization_parent_id_ss'
 
     for org in hierarchy_list:
         trimmed = {
             'id': str(org[from_key]),
-            'label': org['label'],
-            'detail_id': org['detail_id'],
-            'url': reverse('view-organization', args=[org['detail_id']])
+            'label': org['organization_parent_name_ss'],
+            'detail_id': org['organization_pk_i'],
+            'url': reverse('view-organization', args=[org['organization_pk_i']])
         }
         nodes.append(trimmed)
         edges.append({'from': str(org[from_key]), 'to': org[to_key]})

--- a/solr_configs/conf/schema.xml
+++ b/solr_configs/conf/schema.xml
@@ -164,6 +164,8 @@
 
     <dynamicField name="*_dt"  type="date"    indexed="true"  stored="true"/>
     <dynamicField name="*_dts" type="date"    indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_dr" type="daterange"    indexed="true"  stored="true"/>
+    <dynamicField name="*_drs" type="daterange"    indexed="true"  stored="true" multiValued="true" />
     <dynamicField name="*_p"  type="location" indexed="true" stored="true"/>
     <dynamicField name="*_srpt"  type="location_rpt" indexed="true" stored="true"/>
 
@@ -361,7 +363,7 @@
     <fieldType name="tdate" class="solr.TrieDateField" docValues="true" precisionStep="6" positionIncrementGap="0"/>
     <fieldType name="tdates" class="solr.TrieDateField" docValues="true" precisionStep="6" positionIncrementGap="0" multiValued="true"/>
 
-
+    <fieldType name="daterange" class="solr.DateRangeField" />
     <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
     <fieldType name="binary" class="solr.BinaryField"/>
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -444,7 +444,6 @@ a.collapsed .show-less {
     outline: none;
 }
 
-
 /* ============= */
 /* media queries */
 /* ============= */

--- a/static/js/command_chart.js
+++ b/static/js/command_chart.js
@@ -98,7 +98,7 @@ var CommandChart = {
                         hierarchical: {
                             levelSeparation: 100, // Distance between levels
                             nodeSpacing: 300, // Distance between nodes
-                            direction: 'UD', // Inverts chart
+                            direction: 'DU', // Inverts chart
                             sortMethod: 'directed',
                         }
                     },

--- a/static/js/command_chart.js
+++ b/static/js/command_chart.js
@@ -41,6 +41,7 @@ var CommandChart = {
     show: function() {
 
         // Build charts and add year
+        var display_charts = false;
         $.each(CommandChart.edgelists, function(index, org_data) {
 
             $("#command-chart-" + index).spin()
@@ -48,92 +49,102 @@ var CommandChart = {
             var command_chain_url = org_data['url'];
             var when = org_data['display_date'];
 
-            $.getJSON(command_chain_url, {index: index}, function(obj) {
-
+            $.when($.getJSON(command_chain_url, {index: index})).then(function(obj) {
                 var idx = obj['index'];
                 var cellID = "command-chart-" + idx;
                 var cellYearID = "command-chart-year-" + idx;
                 $('#' + cellID).spin(false);
 
-                var node_list = CommandChart.addMultiFont(obj['nodes']);
-                var edge_list = (obj['edges']);
+                if (obj['nodes'].length > 0){
+                    display_charts = true;
+                    var node_list = CommandChart.addMultiFont(obj['nodes']);
+                    var edge_list = (obj['edges']);
 
-                var nodes = new vis.DataSet(node_list);
-                var edges = new vis.DataSet(edge_list);
+                    var nodes = new vis.DataSet(node_list);
+                    var edges = new vis.DataSet(edge_list);
 
-                var container = document.getElementById(cellID);
-                var data = {
-                    nodes: nodes,
-                    edges: edges,
-                };
+                    var container = document.getElementById(cellID);
+                    var data = {
+                        nodes: nodes,
+                        edges: edges,
+                    };
 
-                var options = {
-                    nodes: {
-                        shape: 'box',
-                        fixed: {
-                            x:true,
-                            y:true,
-                        },
-                        shapeProperties: {
-                            borderRadius: 2,
-                        },
-                        color: {
-                            background: '#f4f4f4',
-                            border: '#D6D6D6',
-                            highlight: { // Change color of node on click
-                                background: '#EBEBEB',
+                    var options = {
+                        nodes: {
+                            shape: 'box',
+                            fixed: {
+                                x:true,
+                                y:true,
+                            },
+                            shapeProperties: {
+                                borderRadius: 2,
+                            },
+                            color: {
+                                background: '#f4f4f4',
                                 border: '#D6D6D6',
+                                highlight: { // Change color of node on click
+                                    background: '#EBEBEB',
+                                    border: '#D6D6D6',
+                                },
+                                hover: {
+                                    background:'#e0e0e0',
+                                    border:'#D6D6D6',
+                                },
                             },
-                            hover: {
-                                background:'#e0e0e0',
-                                border:'#D6D6D6',
+                            font: {
+                                color: '#777777',
+                                face: 'Open Sans',
                             },
                         },
-                        font: {
-                            color: '#777777',
-                            face: 'Open Sans',
+                        layout: {
+                            hierarchical: {
+                                levelSeparation: 100, // Distance between levels
+                                nodeSpacing: 300, // Distance between nodes
+                                direction: 'DU', // Inverts chart
+                                sortMethod: 'directed',
+                            }
                         },
-                    },
-                    layout: {
-                        hierarchical: {
-                            levelSeparation: 100, // Distance between levels
-                            nodeSpacing: 300, // Distance between nodes
-                            direction: 'DU', // Inverts chart
-                            sortMethod: 'directed',
-                        }
-                    },
-                    interaction: {
-                        zoomView: true,
-                        dragView: true,
-                        hover:true,
-                    },
-                };
+                        interaction: {
+                            zoomView: true,
+                            dragView: true,
+                            hover:true,
+                        },
+                    };
 
-                var network = new vis.Network(container, data, options);
+                    // $('#org-chart-container').css({
+                    //     'height': '600px'
+                    // })
 
-                if (typeof when != 'undefined' && when !== '') {
-                    $('#' + cellYearID).append(when);
-                } else {
-                    $('#' + cellYearID).append(CommandChart.dateMissingString);
-                }
+                    var network = new vis.Network(container, data, options);
 
-                // Bind click event to individual nodes
-                network.on("selectNode", function (params) {
-                    if (params.nodes.length === 1) {
-                        node = nodes.get(params.nodes[0]);
-                        window.location = node.url;
+                    if (typeof when != 'undefined' && when !== '') {
+                        $('#' + cellYearID).append(when);
+                    } else {
+                        $('#' + cellYearID).append(CommandChart.dateMissingString);
                     }
-                });
 
-                // Transform cursor (from hand into pointed finger and back again)
-                network.on("hoverNode", function (params) {
-                    network.canvas.body.container.style.cursor = 'pointer'
-                });
+                    // Bind click event to individual nodes
+                    network.on("selectNode", function (params) {
+                        if (params.nodes.length === 1) {
+                            node = nodes.get(params.nodes[0]);
+                            window.location = node.url;
+                        }
+                    });
 
-                network.on("blurNode", function (params) {
-                    network.canvas.body.container.style.cursor = 'default'
-                });
+                    // Transform cursor (from hand into pointed finger and back again)
+                    network.on("hoverNode", function (params) {
+                        network.canvas.body.container.style.cursor = 'pointer'
+                    });
 
+                    network.on("blurNode", function (params) {
+                        network.canvas.body.container.style.cursor = 'default'
+                    });
+                } else {
+                    $('#' + cellID).hide();
+                }
+                if(!display_charts){
+                    $('#command-chain').hide();
+                }
             });
 
         });

--- a/templates/person/view.html
+++ b/templates/person/view.html
@@ -321,12 +321,14 @@
 
             var edgelists = {{command_chain|safe}};
 
-            var chart = CommandChart;
-            chart.dateMissingString = "{% trans 'No known end date' %}"
-            chart.edgelists = edgelists;
+            if (edgelists){
+                var chart = CommandChart;
+                chart.dateMissingString = "{% trans 'No known end date' %}"
+                chart.edgelists = edgelists;
 
-            chart.initCarousel();
-            chart.show();
+                chart.initCarousel();
+                chart.show();
+            }
         });
 
         </script>

--- a/templates/person/view.html
+++ b/templates/person/view.html
@@ -139,7 +139,7 @@
     {% endif %}
 
     {% if command_chain %}
-    <div class="row">
+    <div id="command-chain" class="row">
         <div class="col-sm-12">
             <h3 id="chain-of-command">
                 <i class="fa fa-fw fa-sitemap fa-rotate-180"></i>


### PR DESCRIPTION
I spent another hour or so on this today and got it to the point where I have charts rendering but, I want to put it down for the moment since I think it kinda represents something that we weren't really planning to follow all the way through in this scope. The good news is that it takes us from waiting for perhaps 20 or 30 seconds for the charts to appear to never even seeing the spinner (the queries, when run in Solr, take about 2-3 milliseconds which represents a ~10,000x performance boost). 

However, I think we'll also want to put some time into double checking the structure here as well as maybe thinking about the [Sani Abacha bug](#352) that we uncovered a while back. Reading through the comments over there, I think we should be able to achieve a better results with the approach in this pull request but I think we'll want to perhaps have more of a focus on this feature in particular so that we get it right. I guess the main take away is that, the org charts are definitely something that we can do and quickly but with great viz-power comes great viz-responsibility.