### PR TITLE
Upgrade Django

### DIFF
--- a/membershipperson/migrations/0008_auto_20180814_1449.py
+++ b/membershipperson/migrations/0008_auto_20180814_1449.py
@@ -46,4 +46,10 @@ class Migration(migrations.Migration):
             WHERE membershipperson_membershippersonendcontext.value_id = s.id
         '''),
         migrations.RunPython(remake_views),
+        migrations.RunSQL('''
+            ALTER TABLE membershipperson_membershippersonstartcontext DROP COLUMN value_id
+        '''),
+        migrations.RunSQL('''
+            ALTER TABLE membershipperson_membershippersonendcontext DROP COLUMN value_id
+        '''),
     ]

--- a/organization/models.py
+++ b/organization/models.py
@@ -3,7 +3,7 @@ import uuid
 import reversion
 
 from django.db import models
-from django.db.models.functions import Coalesce, Value
+from django.db.models.functions import Coalesce
 from django.utils.translation import ugettext as _
 from django.conf import settings
 
@@ -80,7 +80,7 @@ class Organization(models.Model, BaseModel, VersionsMixin):
         assocs = self.associationorganization_set\
                      .annotate(lcd=Coalesce('object_ref__associationstartdate__value',
                                             'object_ref__associationenddate__value',
-                                            Value('1000-0-0')))\
+                                            models.Value('1000-0-0')))\
                      .order_by('-lcd')
 
         return assocs
@@ -96,7 +96,7 @@ class Organization(models.Model, BaseModel, VersionsMixin):
         empls = self.emplacementorganization_set\
                     .annotate(lcd=Coalesce('object_ref__emplacementstartdate__value',
                                            'object_ref__emplacementenddate__value',
-                                           Value('1000-0-0')))\
+                                           models.Value('1000-0-0')))\
                     .order_by('-lcd')
 
         return empls

--- a/person/models.py
+++ b/person/models.py
@@ -3,7 +3,7 @@ import uuid
 import reversion
 
 from django.db import models, connection
-from django.db.models.functions import Coalesce, Value
+from django.db.models.functions import Coalesce
 from django.contrib.gis.geos import Point
 from django.utils.translation import ugettext as _
 from django.db.models import Max
@@ -91,7 +91,7 @@ class Person(models.Model, BaseModel, VersionsMixin):
                    .select_related('object_ref')\
                    .annotate(lcd=Coalesce('object_ref__membershippersonfirstciteddate__value',
                                           'object_ref__membershippersonlastciteddate__value',
-                                          Value('1000-0-0')))\
+                                          models.Value('1000-0-0')))\
                    .order_by('-lcd')
 
         return mems

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dj-database-url==0.3.0
-Django<1.10
+Django<2.0
 django-jsonview==0.5.0
 django-localeurl==2.0.2
 django-reversion==2.0.4


### PR DESCRIPTION
We were on an old version of Django for no particular reason. This upgrades us to the latest release less than 2.0. We'll eventually want to go ahead and upgrade to > 2.0 but there are some significant API changes that we'll need to reckon with.