### PR TITLE
Import relavant ways as part of bulk OSM import 

### DIFF
--- a/sfm_pc/management/commands/import_osm.py
+++ b/sfm_pc/management/commands/import_osm.py
@@ -114,6 +114,10 @@ class Command(BaseCommand):
             CREATE INDEX geometry_index ON osm_data USING GIST (geometry)
         """, raise_exc=False)
 
+        self.executeTransaction("""
+            ALTER TABLE osm_data ALTER COLUMN admin_level TYPE VARCHAR
+        """, raise_exc=False)
+
     def makeRawTable(self, country):
         create = '''
             CREATE TABLE raw_osm_data AS
@@ -122,7 +126,7 @@ class Command(BaseCommand):
                 localname,
                 hierarchy,
                 tags,
-                admin_level,
+                admin_level::VARCHAR,
                 name,
                 country_code,
                 geometry,
@@ -135,7 +139,7 @@ class Command(BaseCommand):
                 name AS localname,
                 NULL::VARCHAR[] AS hierarchy,
                 NULL::jsonb AS tags,
-                admin_level::integer,
+                admin_level::VARCHAR,
                 name AS name,
                 country_code,
                 ST_Transform(way, 4326) AS geometry,
@@ -149,7 +153,7 @@ class Command(BaseCommand):
                 MAX(name) AS localname,
                 NULL::VARCHAR[] AS hierarchy,
                 NULL::jsonb AS tags,
-                MAX(admin_level)::integer,
+                MAX(admin_level)::VARCHAR,
                 MAX(name) AS name,
                 NULL::VARCHAR AS country_code,
                 ST_Transform(ST_Union(way), 4326) AS geometry,

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -451,7 +451,7 @@ def test_boolean_false_to_true(setUp, fake_signal):
 
 
 @pytest.mark.django_db
-def test_boolean_true_no_sources(setUp):
+def test_boolean_true_no_sources(setUp, fake_signal):
     membership = MembershipPerson.objects.filter(membershippersonrealstart__value=False).first()
     person = membership.member.get_value().value
 
@@ -468,6 +468,9 @@ def test_boolean_true_no_sources(setUp):
 
     assert response.status_code == 302
     assert membership.realstart.get_value().value == True
+
+    fake_signal.assert_called_with(object_id=membership.id,
+                                   sender=MembershipPerson)
 
 
 @pytest.mark.django_db

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -16,8 +16,6 @@ from reversion.models import Version
 from source.models import Source, AccessPoint
 from person.models import Person
 
-from sfm_pc.signals import update_source_index
-
 @pytest.fixture()
 @pytest.mark.django_db
 def setUp(client, request):


### PR DESCRIPTION
During the most recent volley of spreadsheet imports, it became clear that we need ways, too. So, this imports them so that the locations that we have that are OSM ways will be valid.