### PR TITLE
Fix urls in Countries overview page

### DIFF
--- a/templates/sfm/countries.html
+++ b/templates/sfm/countries.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load help %}
 {% block content %}
+<div class="row">
     <div class="col-xs-12">
         <div class="panel panel-default" style="min-height:150px">
             <div class="panel-heading">
@@ -63,11 +64,11 @@
                             </div>
                             <div class="col-xs-12 col-sm-8">
                                 <h4><strong><i class="fa fa-fw fa-clock-o"></i> {% trans "Collections" %}</strong></h4>
-                                <a href="{% url 'search' %}?selected_facets=country_ss_fct_exact:Egypt&selected_facets=organization_adminlevel1_ss_fct_exact:Cairo+Governorate&selected_facets=organization_classification_ss_fct_exact:Police&entity_type=Person&entity_type=Organization&entity_type=Violation">
-                                    <p>{% trans "Police in Cairo" %}</p>
+                                <a href="{% url 'search' %}?selected_facets=country_ss_fct_exact%3AEgypt&selected_facets=organization_parent_name_ss_fct_exact%3ACairo+Governorate+Security+Directorate&entity_type=Organization&Organization_rows=20">
+                                    <p>{% trans "Police in Cairo Governorate" %}</p>
                                 </a>
-                                <a href="{% url 'search' %}?selected_facets=country_ss_fct_exact:Egypt&selected_facets=organization_adminlevel1_ss_fct_exact:Alexandria%20Governorate&entity_type=Organization&selected_facets=organization_classification_ss_fct_exact:Police">
-                                    <p>{% trans "Police in Alexandria" %}</p>
+                                <a href="{% url 'search' %}?Organization_rows=20&selected_facets=country_ss_fct_exact:Egypt&entity_type=Organization&selected_facets=organization_parent_name_ss_fct_exact%3AAlexandria%20Governorate%20Security%20Directorate">
+                                    <p>{% trans "Police in Alexandria Governorate" %}</p>
                                 </a>
                             </div>
                         </div>
@@ -164,11 +165,6 @@
                             </div>
                             <div class="col-xs-12 col-sm-8">
                                 <h4><strong><i class="fa fa-fw fa-clock-o"></i> {% trans "Collections" %}</strong></h4>
-                                <a href="{% url 'search' %}?selected_facets=country_ss_fct_exact:Myanmar&entity_type=Organization&selected_facets=organization_adminlevel1_ss_fct_exact:Rakhine">
-                                    <p>{% trans "Units in Rakhine State" %}</p>
-                                </a>
-                                <a href="{% url 'search' %}?selected_facets=country_ss_fct_exact:Myanmar&entity_type=Organization&selected_facets=organization_adminlevel1_ss_fct_exact:Shan%20State">
-                                    <p>{% trans "Units in Shan State"%}</p>
                                 <a href="{% url 'search' %}?selected_facets=country_ss_fct_exact:Myanmar&entity_type=Organization&selected_facets=organization_parent_name_ss_fct_exact:Western%20Regional%20Military%20Command">
                                     <p>{% trans "Units under Western Region Military Command"%}</p>
                                 </a>
@@ -219,7 +215,9 @@
                             <div class="col-xs-12 col-sm-8">
                                 <h4><strong><i class="fa fa-fw fa-clock-o"></i> {% trans "Collections" %}</strong></h4>
                                 <a href="{% url 'view-organization' boyona.uuid %}"><p>{% trans "Operation BOYONA" %}</p></a>
-                                <a href="{% url 'search' %}?start_date=2010-02-09&end_date=2015-05-28&Organization_rows=25&selected_facets=country_ss_fct_exact:Nigeria&entity_type=Organization&selected_facets=organization_classification_ss_fct_exact:Army"><p>{% trans "Nigerian Army under President Jonathan (9 February 2010 to 28 May 2015)" %}</p></a>
+                                <a href="{% url 'search' %}?start_date=2010-02-09&end_date=2015-05-28&Organization_rows=25&selected_facets=country_ss_fct_exact:Nigeria&entity_type=Organization&selected_facets=organization_classification_ss_fct_exact:Army">
+				    <p>{% trans "Nigerian Army under President Jonathan (9 February 2010 to 28 May 2015)" %}</p>
+				</a>
                             </div>
                         </div>
                         <div class="row">
@@ -260,11 +258,11 @@
                             </div>
                             <div class="col-xs-12 col-sm-8">
                                 <h4><strong><i class="fa fa-fw fa-clock-o"></i> {% trans "Collections" %}</strong></h4>
-                                <a href="{% url 'search' %}?selected_facets=country_ss_fct_exact:Philippines&selected_facets=organization_classification_ss_fct_exact:Police&entity_type=Organization&selected_facets=organization_adminlevel1_ss_fct_exact:Metro%20Manila">
-                                    <p>{% trans "Police in Metro Manila" %}</p>
+                                <a href="{% url 'search' %}?selected_facets=country_ss_fct_exact:Philippines&selected_facets=organization_parent_name_ss_fct_exact:Manila%20Police%20District&entity_type=Organization&selected_facets=organization_classification_ss_fct_exact%3APolice">
+                                    <p>{% trans "Police under Manila Police District" %}</p>
                                 </a>
-                                <a href="{% url 'search' %}?selected_facets=country_ss_fct_exact:Philippines&selected_facets=organization_classification_ss_fct_exact:Police&entity_type=Organization&selected_facets=organization_adminlevel1_ss_fct_exact:Cebu">
-                                    <p>{% trans "Police in Cebu" %}</p>
+                                <a href="{% url 'search' %}?selected_facets=country_ss_fct_exact:Philippines&selected_facets=organization_classification_ss_fct_exact:Police&entity_type=Organization&selected_facets=organization_parent_name_ss_fct_exact%3ACebu%20City%20Police%20Office">
+                                    <p>{% trans "Police under Cebu City Police Office" %}</p>
                                 </a>
                             </div>
                         </div>
@@ -396,12 +394,7 @@
                             </div>
                             <div class="col-xs-12 col-sm-8">
                                 <h4><strong><i class="fa fa-fw fa-clock-o"></i> {% trans "Collections" %}</strong></h4>
-                                <a href="{% url 'search' %}?selected_facets=country_ss_fct_exact:Uganda&selected_facets=organization_classification_ss_fct_exact:Police&entity_type=Person&entity_type=Violation&entity_type=Source&entity_type=Organization&selected_facets=organization_adminlevel1_ss_fct_exact:Kampala">
-                                    <p>{% trans "Police in Kampala" %}</p>
-                                </a>
-                                <a href="{% url 'search' %}?start_date=&end_date=&q=&selected_facets=country_ss_fct_exact:Uganda&selected_facets=organization_classification_ss_fct_exact:Police&entity_type=Organization&selected_facets=organization_adminlevel1_ss_fct_exact:Wakiso">
-                                    <p>{% trans "Police in Wakiso" %}</p>
-                                </a>
+                                    <p>{% trans "No collection yet" %}</p>
                             </div>
                         </div>
                         <div class="row">


### PR DESCRIPTION
- Changes to the way admin1 locations broke some stuff;
- For now, we can't show facets that are based on admin1;
- In this page, four links have been removed, and four updated using available facets;
- Also added a missing `<div>`, which was causing the Bangladesh panel on the countries page to be a few px more narrow than the others.