### PR TITLE
Update search index when creating/updating Sources

### DIFF
--- a/sfm_pc/signals.py
+++ b/sfm_pc/signals.py
@@ -47,3 +47,11 @@ def update_composition_index(sender, **kwargs):
 
     update_index('organizations', composition.parent.get_value().value.uuid)
     update_index('organizations', composition.child.get_value().value.uuid)
+
+
+@receiver(post_save, sender=Source)
+def update_source_index(sender, **kwargs):
+    # An instance will always be sent by the post_save receiver. See:
+    # https://docs.djangoproject.com/en/2.2/ref/signals/#django.db.models.signals.pre_save
+    instance = kwargs['instance']
+    update_index('sources', instance.uuid)

--- a/sfm_pc/signals.py
+++ b/sfm_pc/signals.py
@@ -54,4 +54,4 @@ def update_source_index(sender, **kwargs):
     # An instance will always be sent by the post_save receiver. See:
     # https://docs.djangoproject.com/en/2.2/ref/signals/#django.db.models.signals.pre_save
     instance = kwargs['instance']
-    update_index('sources', instance.uuid)
+    update_index('sources', str(instance.uuid))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+from unittest import mock
 
 import pytest
 
@@ -45,14 +46,19 @@ def setUp(client, request, user):
 def sources(user):
     sources = []
 
-    for index in range(5):
-        source = Source.objects.create(title='Test {}'.format(index),
-                                       publication='Publication {}'.format(index),
-                                       publication_country='United States',
-                                       published_on='2018-01-01',
-                                       source_url='https://test.com/test-{}'.format(index),
-                                       user=user)
-        sources.append(source)
+    # Since we only want this mock to be applied during this specific block,
+    # use the built-in mock.patch() method instead of pytest-mock's fixture.
+    with mock.patch('sfm_pc.signals.update_index', autospec=True):
+        for index in range(5):
+            source = Source.objects.create(
+                title='Test {}'.format(index),
+                publication='Publication {}'.format(index),
+                publication_country='United States',
+                published_on='2018-01-01',
+                source_url='https://test.com/test-{}'.format(index),
+                user=user
+            )
+            sources.append(source)
 
     return sources
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = (
     'membershipperson',
     'composition',
     'source',
+    'search',
     'area',
     'association',
     'geosite',
@@ -160,7 +161,7 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 )
 
-LOGIN_URL = reverse_lazy('account_login')
+LOGIN_URL = reverse_lazy('login')
 LOGIN_REDIRECT_URL = '/'
 
 AUTHENTICATION_BACKENDS = (


### PR DESCRIPTION
## Overview

When creating or updating a Source, make sure to add/update it in the search index.

Connects #566, connects #504.

## Testing instructions

- Confirm tests pass on Travis
- Navigate to http://localhost:8000/en/source/create/ and create a source called `Test source`
- Navigate to http://localhost:8000/en/search/?entity_type=Source, search for `Test source`, and confirm you see your source in the search results