### PR TITLE
Source detail page refinements

### DIFF
--- a/source/models.py
+++ b/source/models.py
@@ -44,13 +44,16 @@ class Source(models.Model, VersionsMixin):
         from django.core.urlresolvers import reverse
         return reverse('view-source', args=[self.uuid])
 
-    def get_evidenced(self):
+    def get_evidenced(self, access_point_id=None):
         evidenced = []
 
         for prop in dir(self):
 
             if prop.endswith('_related'):
-                related = getattr(self, prop).all()
+                related = getattr(self, prop)
+                if access_point_id:
+                    related = related.filter(accesspoints__uuid=access_point_id)
+                related = related.all()
 
                 if related:
 
@@ -58,10 +61,6 @@ class Source(models.Model, VersionsMixin):
                         evidenced.append(rel)
 
         return evidenced
-
-    @property
-    def archive_urls(self):
-        return ' | '.join(a.archive_url for a in self.accesspoint_set.all())
 
     @property
     def revert_url(self):

--- a/source/models.py
+++ b/source/models.py
@@ -89,7 +89,7 @@ class AccessPoint(models.Model, VersionsMixin):
             # that the string should be plural. See:
             # https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#pluralization
             is_range = 2 if ('-' in self.page_number or ', ' in self.page_number) else 1
-            # Translators: This prefix references to the page numbers in an access point.
+            # Translators: This fragment references to the page numbers in an access point.
             pages_str = ngettext(
                 '(Page %(pages)s)',
                 '(Pages %(pages)s)',

--- a/source/urls.py
+++ b/source/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
 from source.views import get_sources, SourceCreate, source_autocomplete, \
-    SourceView, SourceUpdate, SourceRevertView, StashSourceView, \
+    SourceView, SourceEvidenceView, SourceUpdate, SourceRevertView, StashSourceView, \
     AccessPointUpdate, AccessPointCreate, AccessPointDetail, get_citation, \
     publication_autocomplete
 
@@ -13,6 +13,7 @@ urlpatterns = [
     url(r'^add-access-point/(?P<source_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', AccessPointCreate.as_view(), name="add-access-point"),
     url(r'^view-access-point/(?P<source_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', AccessPointDetail.as_view(), name="view-access-point"),
     url(r'^view/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', SourceView.as_view(), name="view-source"),
+    url(r'^view/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/(?P<access_point_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', SourceEvidenceView.as_view(), name="view-source-with-evidence"),
     url(r'^revert/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', SourceRevertView.as_view(), name="revert-source"),
     url(r'^autocomplete/$', source_autocomplete, name="source-autocomplete"),
     url(r'^stash/$', StashSourceView.as_view(), name="stash-source"),

--- a/source/views.py
+++ b/source/views.py
@@ -40,7 +40,8 @@ class SourceView(LoginRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        evidenced = context['source'].get_evidenced()
+        access_point_id = kwargs.get('point')
+        evidenced = context['source'].get_evidenced(access_point_id)
 
         evidenced_table = []
 

--- a/source/views.py
+++ b/source/views.py
@@ -1,5 +1,5 @@
 import json
-import uuid
+from uuid import uuid4
 import itertools
 import sys
 
@@ -116,7 +116,7 @@ class SourceCreate(SourceEditView, CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context['source_id'] = str(uuid.uuid4())
+        context['source_id'] = str(uuid4())
 
         return context
 

--- a/source/views.py
+++ b/source/views.py
@@ -42,28 +42,27 @@ class SourceView(LoginRequiredMixin, DetailView):
 
         access_point_id = self.request.GET.get('point')
         if access_point_id:
-            evidenced = context['source'].get_evidenced(access_point_id)
+            access_point = AccessPoint.objects.get(uuid=access_point_id)
+            if access_point:
+                evidenced = context['source'].get_evidenced(access_point.uuid)
 
-            evidenced_table = []
+                evidenced_table = []
 
-            for record in evidenced:
-                name = str(record)
-                record_type = record.object_ref._meta.object_name
-                field_name = record._meta.model_name.replace(record_type.lower(), '').title()
-                value = record.value
+                for record in evidenced:
+                    name = str(record)
+                    record_type = record.object_ref._meta.object_name
+                    field_name = record._meta.model_name.replace(record_type.lower(), '').title()
+                    value = record.value
 
-                link = None
+                    link = None
 
-                if record_type in ['Organization', 'Person']:
-                    link = reverse_lazy('view-{}'.format(record_type.lower()), kwargs={'slug': record.object_ref.uuid})
+                    if record_type in ['Organization', 'Person']:
+                        link = reverse_lazy('view-{}'.format(record_type.lower()), kwargs={'slug': record.object_ref.uuid})
 
-                evidenced_table.append([name, record_type, field_name, value, link])
+                    evidenced_table.append([name, record_type, field_name, value, link])
 
-            context['evidenced'] = evidenced_table
-            # Access point IDs will be parsed from query params as Strings, so we
-            # need to convert them to UUIDs in order to compare to access point IDs
-            # that have been retrieved from the database.
-            context['access_point_id'] = uuid.UUID(access_point_id)
+                context['evidenced'] = evidenced_table
+                context['access_point'] = access_point
         return context
 
 

--- a/templates/source/view.html
+++ b/templates/source/view.html
@@ -50,7 +50,7 @@
                         <option></option>
                     {% for point in source.accesspoint_set.all %}
                         <option
-                            value="{{ point.uuid }}"
+                            value="{% url 'view-source-with-evidence' source.uuid point.uuid %}#evidence"
                             {% if point.uuid == access_point.uuid %}selected{% endif %}
                         >
                             {{ point }}
@@ -119,16 +119,13 @@
     $('select#access-point').select2({
         allowClear: true,
         placeholder: 'Select an access point',
-        width: 'resolve'
     }).change(function(event) {
-        // Simulate clicking on a link when a user selects an access point.
-        var accessPointId = event.target.value;
-        if (accessPointId === '') {
-            // Clear the selection.
-            window.location.search = '';
+        var href = event.target.value;
+        if (href === '') {
+            // Clearing the selection should take the user back to the Source detail view
+            href = "{% url 'view-source' source.uuid %}";
         }
-        window.location.hash = 'evidence';
-        window.location.search = 'point=' + accessPointId;
-    });
+        window.location = href;
+    })
 </script>
 {% endblock %}

--- a/templates/source/view.html
+++ b/templates/source/view.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load static %}
 {% block content %}
 <div class="row">
     <div class="col-sm-12">
@@ -59,6 +60,9 @@
                     </select>
                 </div>
             </form>
+            {% if not access_point.uuid %}
+                <div id="spinner" style="height:100px; padding-left:50%; padding-top:50px"></div>
+            {% endif %}
         </div>
         {% else %}
             <p>{% trans "No access points found for this source." %}</p>
@@ -115,11 +119,17 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="{% static 'js/spin.min.js' %}"></script>
 <script type="text/javascript">
     $('select#access-point').select2({
         allowClear: true,
         placeholder: '{% trans "Select an access point" %}',
     }).change(function(event) {
+        // Start the spinner to give a sense of "loading"
+        var spinner = Spinner().spin();
+        $('#spinner').append(spinner.el);
+
+        // Redirect the user
         var href = event.target.value;
         if (href === '') {
             // Clearing the selection should take the user back to the Source detail view

--- a/templates/source/view.html
+++ b/templates/source/view.html
@@ -38,35 +38,43 @@
 <div class="row">
     <div class="col-sm-12">
         <h2 id="evidence">Evidence</h2>
+        <br />
     {% if source.accesspoint_set.count > 0 %}
-        <form>
-            <div class="form-group">
-                <label for="access-point">
-                    {% trans "Select an access point to view records evidenced by this source:" %}
-                </label>
-                <select id="access-point">
-                    <option></option>
-                {% for point in source.accesspoint_set.all %}
-                    <option
-                        value="{{ point.uuid }}"
-                        {% if point.uuid == access_point_id %}selected{% endif %}
-                    >
-                        {{ point }}
-                    </option>
-                {% endfor %}
-                </select>
-            </div>
-        </form>
+        <div class="col-sm-12 col-md-6">
+            <form>
+                <div class="form-group">
+                    <label for="access-point">
+                        {% trans "Select an access point to view records evidenced by this source:" %}
+                    </label>
+                    <select id="access-point" class="form-control">
+                        <option></option>
+                    {% for point in source.accesspoint_set.all %}
+                        <option
+                            value="{{ point.uuid }}"
+                            {% if point.uuid == access_point.uuid %}selected{% endif %}
+                        >
+                            {{ point }}
+                        </option>
+                    {% endfor %}
+                    </select>
+                </div>
+            </form>
+        </div>
         {% else %}
             <p>{% trans "No access points found for this source." %}</p>
         {% endif %}
     </div>
 </div>
 </div>
-{% if access_point_id %}
+{% if access_point.uuid %}
 <div class="row">
     <div class="col-sm-12">
-        <h3>{% trans "This access point evidences the following records:" %}</h3>
+        <h3>
+        {% blocktrans with access_point.archive_url as archive_url%}
+            Access point <a href="{{ archive_url }}">{{ access_point }}</a>
+            evidences the following records:
+        {% endblocktrans %}
+        </h3>
         <table class="table table-striped">
             <thead>
                 <tr>
@@ -108,12 +116,15 @@
 
 {% block extra_js %}
 <script type="text/javascript">
-    $('select#access-point').select2({allowClear: true, placeholder: 'Select an access point'}).change(function(event) {
+    $('select#access-point').select2({
+        allowClear: true,
+        placeholder: 'Select an access point',
+        width: 'resolve'
+    }).change(function(event) {
         // Simulate clicking on a link when a user selects an access point.
         var accessPointId = event.target.value;
         if (accessPointId === '') {
             // Clear the selection.
-            window.location.hash = '';
             window.location.search = '';
         }
         window.location.hash = 'evidence';

--- a/templates/source/view.html
+++ b/templates/source/view.html
@@ -6,17 +6,20 @@
         <div class="jumbotron">
             <div class="row">
                 <div class="col-sm-12">
-                    <h2 class="page-title cited">
-                        <a href="{{ source.source_url }}" target="_blank">
-                            {{ source.title }}
-                        </a>
-                        {% if request.user.is_staff %}
+                    {% if request.user.is_staff %}
+                        <h2>
                             <small class="pull-right">
                                 <a class="btn btn-default" type="button" role="button" href="{% url 'update-source' source.uuid %}">
                                     <i class="fa fa-fw fa-edit"></i>{% trans "Edit" %}
                                 </a>
                             </small>
-                        {% endif %}
+                        </h2>
+                    {% endif %}
+                    <h2 class="page-title cited">
+                        <i class="fa fa-fw fa-paperclip"></i>
+                        <a href="{{ source.source_url }}" target="_blank">
+                            {{ source.title }}
+                        </a>
                     </h2>
                 </div>
             </div>
@@ -25,7 +28,6 @@
                     <p>
                         <strong>Publisher: </strong>{{ source.publication }} ({{ source.publication_country }})<br />
                         <strong>Publication date: </strong>{{ source.published_on }}<br />
-                        <strong>Archive URLs: </strong>{{ source.archive_urls }}<br />
                         <strong>Accessed on: </strong>{{ source.accessed_on }}<br />
                         <strong>Last edited by: </strong>{{ source.user }}
                     </p>
@@ -34,9 +36,23 @@
         </div>
     </div>
 </div>
+{% if source.accesspoint_set.count > 0 %}
+    <div class="row">
+        <div class="col-sm-12">
+            <p><strong>Select an access point</strong> to view records evidenced by this source:</p>
+            <ul>
+                {% for point in source.accesspoint_set.all %}
+                    <li><a href="?point={{ point.uuid }}">{{ point.archive_url }}</a></li>
+                {% endfor %}
+            </ul>
+            </form>
+        </div>
+    </div>
+{% endif %}
+</div>
 <div class="row">
     <div class="col-sm-12">
-        <h2>This source evidences the below data:</h2>
+        <h3>This access point evidences the following records:</h3>
         <table class="table table-striped">
             <thead>
                 <tr>

--- a/templates/source/view.html
+++ b/templates/source/view.html
@@ -26,10 +26,9 @@
             <div class="row">
                 <div class="col-sm-12">
                     <p>
-                        <strong>Publisher: </strong>{{ source.publication }} ({{ source.publication_country }})<br />
-                        <strong>Publication date: </strong>{{ source.published_on }}<br />
-                        <strong>Accessed on: </strong>{{ source.accessed_on }}<br />
-                        <strong>Last edited by: </strong>{{ source.user }}
+                        <strong>{% trans "Publisher:" %} </strong>{{ source.publication }} ({{ source.publication_country }})<br />
+                        <strong>{% trans "Publication date:" %} </strong>{{ source.published_on }}<br />
+                        <strong>{% trans "Last edited by:" %} </strong>{{ source.user }}
                     </p>
                 </div>
             </div>
@@ -38,41 +37,47 @@
 </div>
 <div class="row">
     <div class="col-sm-12">
+        <h2 id="evidence">Evidence</h2>
     {% if source.accesspoint_set.count > 0 %}
-        <p><strong>Select an access point</strong> to view records evidenced by this source:</p>
-        <ul>
-        {% for point in source.accesspoint_set.all %}
-            <li>
-                <a href="?point={{ point.uuid }}">
-                {% if point.uuid == access_point_id %}
-                    <strong>{{ point.archive_url }}</strong>
-                {% else %}
-                    {{ point.archive_url }}
-                {% endif %}
-                </a>
-            </li>
-        {% endfor %}
-        </ul>
-    {% else %}
-        <p>No access points found for this source.</p>
-    {% endif %}
+        <form>
+            <div class="form-group">
+                <label for="access-point">
+                    {% trans "Select an access point to view records evidenced by this source:" %}
+                </label>
+                <select id="access-point">
+                    <option></option>
+                {% for point in source.accesspoint_set.all %}
+                    <option
+                        value="{{ point.uuid }}"
+                        {% if point.uuid == access_point_id %}selected{% endif %}
+                    >
+                        {{ point }}
+                    </option>
+                {% endfor %}
+                </select>
+            </div>
+        </form>
+        {% else %}
+            <p>{% trans "No access points found for this source." %}</p>
+        {% endif %}
     </div>
 </div>
 </div>
-{% if evidenced %}
+{% if access_point_id %}
 <div class="row">
     <div class="col-sm-12">
-        <h3>This access point evidences the following records:</h3>
+        <h3>{% trans "This access point evidences the following records:" %}</h3>
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th>Record Name</th>
-                    <th>Record Type</th>
-                    <th>Fieldname</th>
-                    <th>Value</th>
+                    <th>{% trans "Record Name" %}</th>
+                    <th>{% trans "Record Type" %}</th>
+                    <th>{% trans "Fieldname" %}</th>
+                    <th>{% trans "Value" context "of a database record" %}</th>
                 </tr>
             </thead>
             <tbody>
+            {% if evidenced %}
                 {% for name, type, fieldname, value, link in evidenced %}
                     <tr>
                         <td>{{ name }}</td>
@@ -89,9 +94,30 @@
                         <td>{{ value }}</td>
                     </tr>
                 {% endfor %}
+            {% else %}
+                <tr>
+                    <td>{% trans "No records found for this access point." %}</td>
+                </tr>
+            {% endif %}
             </tbody>
         </table>
     </div>
 </div>
 {% endif %}
+{% endblock %}
+
+{% block extra_js %}
+<script type="text/javascript">
+    $('select#access-point').select2({allowClear: true, placeholder: 'Select an access point'}).change(function(event) {
+        // Simulate clicking on a link when a user selects an access point.
+        var accessPointId = event.target.value;
+        if (accessPointId === '') {
+            // Clear the selection.
+            window.location.hash = '';
+            window.location.search = '';
+        }
+        window.location.hash = 'evidence';
+        window.location.search = 'point=' + accessPointId;
+    });
+</script>
 {% endblock %}

--- a/templates/source/view.html
+++ b/templates/source/view.html
@@ -36,20 +36,30 @@
         </div>
     </div>
 </div>
-{% if source.accesspoint_set.count > 0 %}
-    <div class="row">
-        <div class="col-sm-12">
-            <p><strong>Select an access point</strong> to view records evidenced by this source:</p>
-            <ul>
-                {% for point in source.accesspoint_set.all %}
-                    <li><a href="?point={{ point.uuid }}">{{ point.archive_url }}</a></li>
-                {% endfor %}
-            </ul>
-            </form>
-        </div>
+<div class="row">
+    <div class="col-sm-12">
+    {% if source.accesspoint_set.count > 0 %}
+        <p><strong>Select an access point</strong> to view records evidenced by this source:</p>
+        <ul>
+        {% for point in source.accesspoint_set.all %}
+            <li>
+                <a href="?point={{ point.uuid }}">
+                {% if point.uuid == access_point_id %}
+                    <strong>{{ point.archive_url }}</strong>
+                {% else %}
+                    {{ point.archive_url }}
+                {% endif %}
+                </a>
+            </li>
+        {% endfor %}
+        </ul>
+    {% else %}
+        <p>No access points found for this source.</p>
+    {% endif %}
     </div>
-{% endif %}
 </div>
+</div>
+{% if evidenced %}
 <div class="row">
     <div class="col-sm-12">
         <h3>This access point evidences the following records:</h3>
@@ -83,4 +93,5 @@
         </table>
     </div>
 </div>
+{% endif %}
 {% endblock %}

--- a/templates/source/view.html
+++ b/templates/source/view.html
@@ -118,7 +118,7 @@
 <script type="text/javascript">
     $('select#access-point').select2({
         allowClear: true,
-        placeholder: 'Select an access point',
+        placeholder: '{% trans "Select an access point" %}',
     }).change(function(event) {
         var href = event.target.value;
         if (href === '') {


### PR DESCRIPTION
## Overview

Improve the following aspects of the Source detail page:

- Allow user to select access points
- Provide clearer names for access points to further distinguish them

Connects #392, connects #567

## Demo

![2019-08-08 11 59 13](https://user-images.githubusercontent.com/14170650/62722460-09322f80-b9d4-11e9-9d80-7a84ac576774.gif)

## Testing instructions

### Test a Source with access points

- Navigate to http://localhost:8000/en/search/?q=stars+on+their+shoulders&entity_type=Source and click on the first link
- Scroll through the access point dropdown and confirm that the formatting of all of the access points looks correct (i.e. proper formatting of "Page" vs. "Pages," proper formatting of the date the access point was accessed)
- Select an access point from the dropdown, and confirm you get shown a list of records it evidences
- Clear the access point from the dropdown, and confirm you get taken back to the version of the Source detail view with no evidence

### Test a source with no access points

- Navigate to http://localhost:8000/en/source/create/
- Create a source called `Test source` with no access points
- Navigate to http://localhost:8000/en/search/?entity_type=Source and view your source by searching for it
- Confirm that you see a message indicating there are no records evidenced by the source