### PR TITLE
Issue 581

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,28 @@ django-admin.py makemessages -l fr
 
 This command generates a `.po` file for each language. Rosetta facilitates the editing and compiling of these files. Go to `/rosetta/`, and view the snippets of code, requiring translation, organized by language. Then, translate some text, click "Save and translate next block," and Rosetta compiles the code into Django-friendly translations.
 
+## Tests
+
+To run tests, check the database connection settings in `tests/test_settings.py`. The test suite expects you to have a `postgres` user and postgres running on port `5432`. 
+
+Once the settings and database are configured, you should be able to run all tests from the root folder:
+
+```
+pytest
+```
+
+You can also run a collection of tests, like so:
+
+```
+pytest tests/test_person.py
+```
+
+Or run a single test, like so:
+
+```
+pytest tests/test_person.py::test_no_existing_sources
+```
+
 ## Using the Google Sheet import script
 
 If you're reading this and you're asking yourself, "Why on earth would I ever

--- a/sfm_pc/forms.py
+++ b/sfm_pc/forms.py
@@ -258,17 +258,15 @@ class BaseUpdateForm(BaseEditForm):
 
                     # test for some new values
                     if posted_value > stored_value and not new_sources:
-                        error = forms.ValidationError(_('"%(field_name)s" has new values so it requires sources'),
-                                                    code='invalid',
-                                                    params={'field_name': field})
+                        error = forms.ValidationError(_('This field has new values so it requires sources'),
+                                                    code='invalid')
                         self.add_error(field, error)
                         continue
 
                     # test for all new values
                     if not posted_value & stored_value and not new_sources:
-                        error = forms.ValidationError(_('"%(field_name)s" has new values so it requires sources'),
-                                                    code='invalid',
-                                                    params={'field_name': field})
+                        error = forms.ValidationError(_('This field has new values so it requires sources'),
+                                                    code='invalid')
                         self.add_error(field, error)
                         continue
 
@@ -278,16 +276,14 @@ class BaseUpdateForm(BaseEditForm):
                         stored_value = stored_value.value
 
                     if posted_value and not stored_value and not new_sources:
-                        error = forms.ValidationError(_('"%(field_name)s" now has a value so it requires sources'),
-                                                    code='invalid',
-                                                    params={'field_name': field})
+                        error = forms.ValidationError(_('This field now has a value so it requires sources'),
+                                                    code='invalid')
                         self.add_error(field, error)
                         continue
 
                     if (posted_value != stored_value) and not new_sources:
-                        error = forms.ValidationError(_('The value of "%(field_name)s" changed so it requires sources'),
-                                                    code='invalid',
-                                                    params={'field_name': field})
+                        error = forms.ValidationError(_('This field changed so it requires sources'),
+                                                    code='invalid')
                         self.add_error(field, error)
                         continue
 
@@ -300,9 +296,8 @@ class BaseUpdateForm(BaseEditForm):
                 # This is an attempt to handle those cases.
 
                 if (stored_value is not None or stored_value != set()) and not (existing_sources | posted_sources):
-                    error = forms.ValidationError(_('Please add some sources to "%(field_name)s"'),
-                                                code='invalid',
-                                                params={'field_name': field})
+                    error = forms.ValidationError(_('Please add some sources to this field'),
+                                                code='invalid')
                     self.add_error(field, error)
 
                 self.update_fields.add(field)
@@ -448,9 +443,8 @@ class BaseCreateForm(BaseEditForm):
                 posted_value = self.cleaned_data[field_name]
 
                 if posted_value and not posted_sources:
-                    error = forms.ValidationError(_('"%(field_name)s" requires sources'),
-                                                    code='invalid',
-                                                    params={'field_name': field_name})
+                    error = forms.ValidationError(_('This field requires sources'),
+                                                    code='invalid')
                     self.add_error(field_name, error)
                     continue
 

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -120,7 +120,7 @@ def test_no_source_one_value(setUp, base_people):
 
     assert response.status_code == 200
 
-    assert '"biography" now has a value so it requires sources' in response.context['form'].errors['biography']
+    assert 'This field now has a value so it requires sources' in response.context['form'].errors['biography']
 
 
 @pytest.mark.django_db
@@ -135,7 +135,7 @@ def test_no_source_multiple_value(setUp, base_people):
 
     assert response.status_code == 200
 
-    assert '"aliases" has new values so it requires sources' in response.context['form'].errors['aliases']
+    assert 'This field has new values so it requires sources' in response.context['form'].errors['aliases']
     assert 'This field is required.' in response.context['form'].errors['name']
 
     assert 'Foo' not in [p.get_value().value for p in person.aliases.get_list()]
@@ -154,7 +154,7 @@ def test_no_source_one_new_value(setUp, people):
 
     assert response.status_code == 200
 
-    assert '"aliases" has new values so it requires sources' in response.context['form'].errors['aliases']
+    assert 'This field has new values so it requires sources' in response.context['form'].errors['aliases']
     assert 'This field is required.' in response.context['form'].errors['name']
 
     assert 'Foo' not in [p.get_value().value for p in person.aliases.get_list()]
@@ -177,7 +177,7 @@ def test_no_source_empty_start(setUp, base_people):
 
     assert response.status_code == 200
 
-    assert '"aliases" has new values so it requires sources' in response.context['form'].errors['aliases']
+    assert 'This field has new values so it requires sources' in response.context['form'].errors['aliases']
 
 
 @pytest.mark.django_db
@@ -321,7 +321,7 @@ def test_new_sources_required(setUp, base_people):
 
     assert response.status_code == 200
 
-    assert 'The value of "name" changed so it requires sources' in response.context['form'].errors['name']
+    assert 'This field changed so it requires sources' in response.context['form'].errors['name']
 
 
 @pytest.mark.django_db
@@ -343,7 +343,7 @@ def test_new_sources_required_multi(setUp, people):
 
     assert response.status_code == 200
 
-    assert '"aliases" has new values so it requires sources' in response.context['form'].errors['aliases']
+    assert 'This field has new values so it requires sources' in response.context['form'].errors['aliases']
 
 
 @pytest.mark.django_db
@@ -530,7 +530,7 @@ def test_no_existing_sources(setUp, membership_person):
                           post_data)
 
     assert response.status_code == 200
-    assert 'Please add some sources to "rank"' in response.context['form'].errors['rank']
+    assert 'Please add some sources to this field' in response.context['form'].errors['rank']
 
 
 @pytest.mark.django_db

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,7 +18,7 @@ from django.utils.translation import ugettext_lazy as _
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-DATABASE_URL='postgis://postgres:@127.0.0.1:5432/sfm'
+DATABASE_URL='postgis://derekeder:@127.0.0.1:5432/sfm'
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY='super duper secret'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,7 +18,7 @@ from django.utils.translation import ugettext_lazy as _
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-DATABASE_URL='postgis://derekeder:@127.0.0.1:5432/sfm'
+DATABASE_URL='postgis://postgres:@127.0.0.1:5432/sfm'
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY='super duper secret'


### PR DESCRIPTION
## Overview

This PR removes `field_name` from field validation messages. I believe this is redundant due to the validation message being displayed below each field. Here's an example:

<img width="582" alt="Screen Shot 2019-08-09 at 11 21 04 AM" src="https://user-images.githubusercontent.com/919583/62793704-cf2a6180-ba97-11e9-86fb-7f489def528e.png">

This PR also updates the relevant tests for form validation and provides instructions in the README for running tests.

Connects #581 

## Testing Instructions

* run `pytest`
* try and edit or add a person or organization without sources and confirm the message is shown as expected
