### PR TITLE
Fix violation-edit-locations view

### DIFF
--- a/tests/test_violation.py
+++ b/tests/test_violation.py
@@ -79,6 +79,16 @@ def test_edit_violation(setUp,
 
 
 @pytest.mark.django_db
+def test_edit_violation_locations(setUp, violation):
+    # Make sure we can load the locations edit view.
+    response = setUp.get(reverse_lazy(
+        'edit-violation-locations',
+        kwargs={'slug': violation.uuid}
+    ))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
 def test_change_perpetrator_classification(setUp,
                                            people,
                                            organizations,

--- a/violation/views.py
+++ b/violation/views.py
@@ -57,11 +57,6 @@ class ViolationEditView(BaseUpdateView):
         uuid = self.kwargs[self.slug_field_kwarg]
         return reverse('view-violation', kwargs={'slug': uuid})
 
-    def get_form_kwargs(self):
-        form_kwargs = super().get_form_kwargs()
-        form_kwargs['violation_id'] = self.kwargs['slug']
-        return form_kwargs
-
 
 class ViolationEditBasicsView(ViolationEditView):
     template_name = 'violation/edit-basics.html'
@@ -73,6 +68,11 @@ class ViolationEditBasicsView(ViolationEditView):
         context['basics'] = True
 
         return context
+
+    def get_form_kwargs(self):
+        form_kwargs = super().get_form_kwargs()
+        form_kwargs['violation_id'] = self.kwargs['slug']
+        return form_kwargs
 
     def get_success_url(self):
         violation_id = self.kwargs['slug']


### PR DESCRIPTION
## Overview

This PR fixes a very small bug I noticed while working on other issues. Due to a bug in form initialization, users can't load the `edit-violation-locations` view. Fix the form initialization to allow users to retrieve this view again.

## Testing Instructions

* Confirm the new test passes on Travis
* Navigate to the detail view for a Violation, choose "Edit," select "Locations," and confirm you can load the page
