### PR TITLE
Adding hidden field to organization/edit-personnel

### DIFF
--- a/organization/forms.py
+++ b/organization/forms.py
@@ -178,6 +178,10 @@ class OrganizationCreateMembershipForm(BaseCreateForm, OrganizationMembershipFor
 
 
 class OrganizationPersonnelForm(BaseUpdateForm):
+    class Meta:
+        model = MembershipPerson
+        fields = '__all__'
+
     edit_fields = [
         ('rank', MembershipPersonRank, False),
         ('role', MembershipPersonRole, False),
@@ -213,10 +217,6 @@ class OrganizationPersonnelForm(BaseUpdateForm):
         super().__init__(*args, **kwargs)
 
         self.fields['organization'] = forms.ModelChoiceField(queryset=Organization.objects.filter(uuid=organization_id))
-
-    class Meta:
-        model = MembershipPerson
-        fields = '__all__'
 
 
 class OrganizationCreatePersonnelForm(BaseCreateForm, OrganizationPersonnelForm):

--- a/templates/organization/edit-personnel.html
+++ b/templates/organization/edit-personnel.html
@@ -11,6 +11,7 @@
 
 {% block form_content %}
     <h2>{% trans 'Edit personnel' %}</h2>
+    <input type="hidden" name="organization" value="{{ form.instance.organization.get_value.value.id }}">
     <div class="row member-row field-bg bg-info">
         <div class="col-sm-12">
             {% if form.member.errors %}


### PR DESCRIPTION
## Overview

This PR adds in a hidden field to the "update personnel" form available when editing organizations.  This populates the "Organization" field of the form, which previously had been missing and causing the form to fail silently.

Connects #548 

### Notes

This solves the problem, but isn't an ideal solution. Originally, the code tried to bypass the form and add `fields['organization']` directly to the dict. It didn't work, but was it just implemented incorrectly? One day this could be refactored, but it would affect all organization forms.

## Testing Instructions

1. Navigate to an organization (Home > Units > choose one) and click the 'edit' button.
2. Click the 'personnel' button.
3. Choose an existing person and edit the 'role' field. Edit as many other as you want!
4. Save the form.
5. Confirm the information has been updated in the personnel list.