### PR TITLE
issue 570

### DIFF
--- a/sfm_pc/utils.py
+++ b/sfm_pc/utils.py
@@ -855,6 +855,8 @@ def get_source_context(field_name, access_point, uncommitted=True):
         'publication_country': access_point.source.publication_country,
         'title': access_point.source.title,
         'date_added': None,
+        'published_on': str(access_point.source.published_on),
+        'access_point': str(access_point),
         'source_url': access_point.source.source_url,
         'source_detail_url': reverse('view-source', kwargs={'pk': access_point.source.uuid}),
         'archive_url': access_point.archive_url,

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -79,11 +79,7 @@
                     <a href="<%= source_url %>" target="_blank">
                         <%= publication %>, <%= publication_country %>
                     </a> -
-                    <% if (accessed_on !== '' && archive_url){ %>
-                        {% trans "Access Point" %} <a href="<%= archive_url %>"><%= access_point %></a>
-                    <% } else if (archive_url) { %>
-                        <a href="<%= archive_url %>">{% trans "Access Point" %}</a>
-                    <% } %>
+                    {% trans "Access Point" %} <a href="<%= archive_url %>"><%= access_point %></a>
                     <% if (page_number){ %>
                         page <%= page_number %>
                     <% } %>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -75,12 +75,12 @@
                 </a>
                 </br>
                 <small>
-                    <%= date_added %> -
+                    <%= published_on %> -
                     <a href="<%= source_url %>" target="_blank">
                         <%= publication %>, <%= publication_country %>
                     </a> -
                     <% if (accessed_on !== '' && archive_url){ %>
-                        {% trans "Access Point" %} <a href="<%= archive_url %>"><%= accessed_on %></a>
+                        {% trans "Access Point" %} <a href="<%= archive_url %>"><%= access_point %></a>
                     <% } else if (archive_url) { %>
                         <a href="<%= archive_url %>">{% trans "Access Point" %}</a>
                     <% } %>

--- a/templates/partials/access_point_input.html
+++ b/templates/partials/access_point_input.html
@@ -6,6 +6,8 @@
     data-source_url="{{ source_url }}"
     data-source_detail_url="{% url 'view-source' source_id %}"
     data-source_publication_country="{{ publication_country|default_if_none:"" }}"
+    data-published_on="{{ published_on|default_if_none:"" }}"
+    data-access_point="{{ access_point|default_if_none:"" }}"
     data-publication="{{ publication|default_if_none:"" }}"
     data-archive_url="{{ archive_url|default_if_none:"" }}"
     data-page_number="{{ page_number|default_if_none:"" }}"

--- a/templates/partials/access_point_input.html
+++ b/templates/partials/access_point_input.html
@@ -6,7 +6,7 @@
     data-source_url="{{ source_url }}"
     data-source_detail_url="{% url 'view-source' source_id %}"
     data-source_publication_country="{{ publication_country|default_if_none:"" }}"
-    data-published_on="{{ published_on|default_if_none:"" }}"
+    data-published_on="{{ published_on|default:"Publication date unavailable" }}"
     data-access_point="{{ access_point|default_if_none:"" }}"
     data-publication="{{ publication|default_if_none:"" }}"
     data-archive_url="{{ archive_url|default_if_none:"" }}"


### PR DESCRIPTION
## Overview

On edit pages, adds `published_on` and `access_point` to the context for sources and updates the display of sources.

Connects #570 

### Demo

With this PR, this is how sources are displayed on edit pages

<img width="585" alt="Screen Shot 2019-08-13 at 4 38 11 PM" src="https://user-images.githubusercontent.com/919583/62979208-d380b280-bde8-11e9-9568-1e0537c2529b.png">

## Testing Instructions

* Navigate to `~/en/organization/edit/composition/76cd0d81-1c70-4630-bf8b-5876868942ee/4/` and confirm sources are displaying as expected
* View locations, personnel and incidents and confirm sources display as expected

