### PR TITLE
issue 551

### DIFF
--- a/templates/organization/edit-basics.html
+++ b/templates/organization/edit-basics.html
@@ -222,7 +222,7 @@
                 <select id="id_open_ended" class="form-control" name="open_ended">
                     <option value="">------</option>
                     {% for value, choice in form.fields.open_ended.choices %}
-                        {% if form.instance.open_ended.get_value.value == choice %}
+                        {% if form.instance.open_ended.get_value.value == value %}
                             <option value="{{ value }}" selected=true>{{ choice }}</option>
                         {% else %}
                             <option value="{{ value }}">{{ choice }}</option>


### PR DESCRIPTION
## Overview

Sets proper value for `open-ended` when editing Organization basics

Connects #551

## Testing Instructions

* Log in and navigate to `~/en/organization/edit/76cd0d81-1c70-4630-bf8b-5876868942ee/`
* Confirm that `Open-Ended?` is set to `Yes`
* Change `Open-Ended?` to `No` and save. Confirm the new value is displayed
