### PR TITLE
issue 438

### DIFF
--- a/templates/organization/create-basics.html
+++ b/templates/organization/create-basics.html
@@ -167,6 +167,30 @@
             <input type="hidden" value="1" name="firstciteddate_confidence">
         </div>
     </div>
+    <div class="row realstart-row field-bg">
+        <div class="col-sm-12">
+            {% if form.realstart.errors %}
+                <div class="form-group has-error has-feedback">
+            {% else %}
+                <div class="form-group">
+            {% endif %}
+                <div class="checkbox">
+                    <label class="control-label">
+                        {% if form.realstart.data %}
+                            <input type="checkbox" name="realstart" id="id_realstart" checked="true" /> {{ form.realstart.label }}
+                        {% else %}
+                            <input type="checkbox" name="realstart" id="id_realstart" /> {{ form.realstart.label }}
+                        {% endif %}
+                    </label>
+                </div>
+                {% if form.realstart.errors %}
+                    {% for error in form.realstart.errors %}
+                    <span class="help-block"><i class="fa fa-remove"> </i> {{error}}</span>
+                    {% endfor %}
+                {% endif %}
+            </div>
+        </div>
+    </div>
     <div class="row lastciteddate-row field-bg">
         <div class="col-sm-12">
             {% if form.lastciteddate.errors %}
@@ -190,30 +214,6 @@
         </div>
         <div id="id_lastciteddate_confidence">
             <input type="hidden" value="1" name="lastciteddate_confidence">
-        </div>
-    </div>
-    <div class="row realstart-row field-bg">
-        <div class="col-sm-12">
-            {% if form.realstart.errors %}
-                <div class="form-group has-error has-feedback">
-            {% else %}
-                <div class="form-group">
-            {% endif %}
-                <div class="checkbox">
-                    <label class="control-label">
-                        {% if form.realstart.data %}
-                            <input type="checkbox" name="realstart" id="id_realstart" checked="true" /> {{ form.realstart.label }}
-                        {% else %}
-                            <input type="checkbox" name="realstart" id="id_realstart" /> {{ form.realstart.label }}
-                        {% endif %}
-                    </label>
-                </div>
-                {% if form.realstart.errors %}
-                    {% for error in form.realstart.errors %}
-                    <span class="help-block"><i class="fa fa-remove"> </i> {{error}}</span>
-                    {% endfor %}
-                {% endif %}
-            </div>
         </div>
     </div>
     <div class="row open_ended-row field-bg">

--- a/templates/organization/edit-basics.html
+++ b/templates/organization/edit-basics.html
@@ -162,6 +162,30 @@
             <input type="hidden" value="{{ form.instance.firstciteddate.get_value.confidence }}" name="firstciteddate_confidence">
         </div>
     </div>
+    <div class="row realstart-row field-bg">
+        <div class="col-sm-12">
+            {% if form.realstart.errors %}
+                <div class="form-group has-error has-feedback">
+            {% else %}
+                <div class="form-group">
+            {% endif %}
+                <div class="checkbox">
+                    <label class="control-label">
+                        {% if form.instance.realstart.get_value.value %}
+                            <input type="checkbox" name="realstart" id="id_realstart" checked="true" /> {{ form.realstart.label }}
+                        {% else %}
+                            <input type="checkbox" name="realstart" id="id_realstart" /> {{ form.realstart.label }}
+                        {% endif %}
+                    </label>
+                </div>
+                {% if form.realstart.errors %}
+                    {% for error in form.realstart.errors %}
+                    <span class="help-block"><i class="fa fa-remove"> </i> {{error}}</span>
+                    {% endfor %}
+                {% endif %}
+            </div>
+        </div>
+    </div>
     <div class="row lastciteddate-row field-bg">
         <div class="col-sm-12">
             {% if form.lastciteddate.errors %}
@@ -185,30 +209,6 @@
         </div>
         <div id="id_lastciteddate_confidence">
             <input type="hidden" value="{{ form.instance.lastciteddate.get_value.confidence }}" name="lastciteddate_confidence">
-        </div>
-    </div>
-    <div class="row realstart-row field-bg">
-        <div class="col-sm-12">
-            {% if form.realstart.errors %}
-                <div class="form-group has-error has-feedback">
-            {% else %}
-                <div class="form-group">
-            {% endif %}
-                <div class="checkbox">
-                    <label class="control-label">
-                        {% if form.instance.realstart.get_value.value %}
-                            <input type="checkbox" name="realstart" id="id_realstart" checked="true" /> {{ form.realstart.label }}
-                        {% else %}
-                            <input type="checkbox" name="realstart" id="id_realstart" /> {{ form.realstart.label }}
-                        {% endif %}
-                    </label>
-                </div>
-                {% if form.realstart.errors %}
-                    {% for error in form.realstart.errors %}
-                    <span class="help-block"><i class="fa fa-remove"> </i> {{error}}</span>
-                    {% endfor %}
-                {% endif %}
-            </div>
         </div>
     </div>
     <div class="row open_ended-row field-bg">


### PR DESCRIPTION
## Overview

Changed ordering of start date field when editing an organization from:

* Organization:date_first_cited
* Organization:date_last_cited
* **start date of Organization? Y/N**
* Organization:open_ended? Y/N/E

To:

* Organization:date_first_cited
* **start date of Organization? Y/N**
* Organization:date_last_cited
* Organization:open_ended? Y/N/E

Connects #438 

### Demo and Testing Instructions

Navigate to an organization page and edit the `basics`. Note the field order for the `start date?` field:

<img width="608" alt="Screen Shot 2019-08-15 at 2 32 05 PM" src="https://user-images.githubusercontent.com/919583/63121203-82e49300-bf69-11e9-8ce6-64c966154cc2.png">

