### PR TITLE
Make Incident create/edit forms useable

### DIFF
--- a/sfm_pc/forms.py
+++ b/sfm_pc/forms.py
@@ -243,12 +243,13 @@ class BaseUpdateForm(BaseEditForm):
                     try:
                         posted_value = {v.value for v in posted_value}
                     except AttributeError:
-                        posted_value = set()
+                        posted_value_set = set()
                         for value in posted_value:
                             if value.get_value():
-                                posted_value.add(value.get_value().value)
+                                posted_value_set.add(value.get_value().value)
                             else:
-                                posted_value.add(None)
+                                posted_value_set.add(None)
+                        posted_value = posted_value_set
 
                     stored_value = {str(v.get_value()) for v in field_instance.get_list()}
 

--- a/templates/organization/edit-composition.html
+++ b/templates/organization/edit-composition.html
@@ -140,7 +140,7 @@
                     <select id="id_related_organization" class="form-control" name="parent" readonly>
                         <option value="{{ form.instance.parent.get_value.value.id }}">{{ form.instance.parent.get_value.value }}</option>
                 {% endif %}
-                </select>}
+                </select>
                 {% if form.parent.errors %}
                     {% for error in form.parent.errors %}
                         <span class="help-block"><i class="fa fa-remove"> </i> {{error}}</span>

--- a/templates/person/create-posting.html
+++ b/templates/person/create-posting.html
@@ -21,7 +21,6 @@
     <input type="hidden" name="member" value="{{ person.id }}" />
     <div class="row organization-row field-bg bg-info">
         <div class="col-sm-12">
-            {{ form.cleaned_data }}
             {% if form.organization.errors %}
                 <div class="form-group has-error has-feedback">
             {% else %}

--- a/templates/violation/create-basics.html
+++ b/templates/violation/create-basics.html
@@ -67,7 +67,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.startdate.label }}</label>
-                <input type="text" name="startdate" id="id_startdate" class="form-control" value="{{ form.startdate.data|default_if_none:"" }}">
+                <input type="text" name="startdate" id="id_startdate" class="form-control sourced" value="{{ form.startdate.data|default_if_none:"" }}">
                 {% if form.startdate.errors %}
                     {% for error in form.startdate.errors %}
                     <span class="help-block"><i class="fa fa-remove"> </i> {{error}}</span>
@@ -84,7 +84,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.enddate.label }}</label>
-                <input type="text" name="enddate" id="id_enddate" class="form-control" value="{{ form.enddate.data|default_if_none:"" }}">
+                <input type="text" name="enddate" id="id_enddate" class="form-control sourced" value="{{ form.enddate.data|default_if_none:"" }}">
                 {% if form.enddate.errors %}
                     {% for error in form.enddate.errors %}
                     <span class="help-block"><i class="fa fa-remove"> </i> {{error}}</span>
@@ -101,7 +101,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.types.label }}</label>
-                <select id="id_types" class="form-control" name="types" multiple="multiple">
+                <select id="id_types" class="form-control sourced-dropdown select2-target" name="types" multiple="multiple">
                     {% for type in form.cleaned_data.types %}
                         <option value="{{ type.id }}" selected=true>{{ type.value }}</option>
                     {% endfor %}
@@ -122,7 +122,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.perpetrator.label }}</label>
-                <select id="id_perpetrator" class="form-control" name="perpetrator" multiple="multiple">
+                <select id="id_perpetrator" class="form-control sourced-dropdown select2-target" name="perpetrator" multiple="multiple">
                     {% for type in form.cleaned_data.perpetrator %}
                         <option value="{{ type.value.id }}" selected=true>{{ type.value }}</option>
                     {% endfor %}
@@ -143,7 +143,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.perpetratororganization.label }}</label>
-                <select id="id_perpetratororganization" class="form-control" name="perpetratororganization" multiple="multiple">
+                <select id="id_perpetratororganization" class="form-control sourced-dropdown select2-target" name="perpetratororganization" multiple="multiple">
                     {% for type in form.cleaned_data.perpetratororganization %}
                         <option value="{{ type.value.id }}" selected=true>{{ type.value }}</option>
                     {% endfor %}
@@ -164,7 +164,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.perpetratorclassification.label }}</label>
-                <select id="id_perpetratorclassification" class="form-control" name="perpetratorclassification">
+                <select id="id_perpetratorclassification" class="form-control sourced-dropdown select2-target" name="perpetratorclassification">
                     <option value="{{ form.cleaned_data.perpetratorclassification.id }}" selected=true>
                         {{ form.cleaned_data.perpetratorclassification.value }}
                     </option>
@@ -185,7 +185,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.division_id.label }}</label>
-                <select id="id_division_id" class="form-control" name="division_id">
+                <select id="id_division_id" class="form-control sourced-dropdown select2-target" name="division_id">
                     {% if form.division_id.data %}
                         <option value="{{ form.division_id.data }}">{{ form.division_id.data|country_name }}</option>
                     {% else %}

--- a/templates/violation/create-basics.html
+++ b/templates/violation/create-basics.html
@@ -75,6 +75,14 @@
                 {% endif %}
             </div>
         </div>
+        <div id="id_startdate_source">
+            {% for source in source_info.startdate_source %}
+                {% source_input 'startdate' source %}
+            {% endfor %}
+        </div>
+        <div id="id_startdate_confidence">
+            <input type="hidden" value="1" name="startdate_confidence">
+        </div>
     </div>
     <div class="row enddate-row field-bg">
         <div class="col-sm-12">
@@ -91,6 +99,14 @@
                     {% endfor %}
                 {% endif %}
             </div>
+        </div>
+        <div id="id_enddate_source">
+            {% for source in source_info.enddate_source %}
+                {% source_input 'enddate' source %}
+            {% endfor %}
+        </div>
+        <div id="id_enddate_confidence">
+            <input type="hidden" value="1" name="enddate_confidence">
         </div>
     </div>
     <div class="row types-row field-bg">
@@ -113,6 +129,14 @@
                 {% endif %}
             </div>
         </div>
+        <div id="id_types_source">
+            {% for source in source_info.types_source %}
+                {% source_input 'types' source %}
+            {% endfor %}
+        </div>
+        <div id="id_types_confidence">
+            <input type="hidden" value="1" name="types_confidence">
+        </div>
     </div>
     <div class="row perpetrator-row field-bg">
         <div class="col-sm-12">
@@ -133,6 +157,14 @@
                     {% endfor %}
                 {% endif %}
             </div>
+        </div>
+        <div id="id_perpetrator_source">
+            {% for source in source_info.perpetrator_source %}
+                {% source_input 'perpetrator' source %}
+            {% endfor %}
+        </div>
+        <div id="id_perpetrator_confidence">
+            <input type="hidden" value="1" name="perpetrator_confidence">
         </div>
     </div>
     <div class="row perpetratororganization-row field-bg">
@@ -155,6 +187,14 @@
                 {% endif %}
             </div>
         </div>
+        <div id="id_perpetratororganization_source">
+            {% for source in source_info.perpetratororganization_source %}
+                {% source_input 'perpetratororganization' source %}
+            {% endfor %}
+        </div>
+        <div id="id_perpetratororganization_confidence">
+            <input type="hidden" value="1" name="perpetratororganization_confidence">
+        </div>
     </div>
     <div class="row perpetratorclassification-row field-bg">
         <div class="col-sm-12">
@@ -165,9 +205,11 @@
             {% endif %}
                 <label class="control-label">{{ form.perpetratorclassification.label }}</label>
                 <select id="id_perpetratorclassification" class="form-control sourced-dropdown select2-target" name="perpetratorclassification">
-                    <option value="{{ form.cleaned_data.perpetratorclassification.id }}" selected=true>
-                        {{ form.cleaned_data.perpetratorclassification.value }}
-                    </option>
+                    {% if form.cleaned_data.perpetratorclassification %}
+                        <option value="{{ form.cleaned_data.perpetratorclassification.id }}" selected=true>
+                            {{ form.cleaned_data.perpetratorclassification.value }}
+                        </option>
+                    {% endif %}
                 </select>
                 {% if form.perpetratorclassification.errors %}
                     {% for error in form.perpetratorclassification.errors %}
@@ -175,6 +217,14 @@
                     {% endfor %}
                 {% endif %}
             </div>
+        </div>
+        <div id="id_perpetratorclassification_source">
+            {% for source in source_info.perpetratorclassification_source %}
+                {% source_input 'perpetratorclassification' source %}
+            {% endfor %}
+        </div>
+        <div id="id_perpetratorclassification_confidence">
+            <input type="hidden" value="1" name="perpetratorclassification_confidence">
         </div>
     </div>
     <div class="row division_id-row field-bg">
@@ -201,6 +251,14 @@
                     {% endfor %}
                 {% endif %}
             </div>
+        </div>
+        <div id="id_division_id_source">
+            {% for source in source_info.division_id_source %}
+                {% source_input 'division_id' source %}
+            {% endfor %}
+        </div>
+        <div id="id_division_id_confidence">
+            <input type="hidden" value="1" name="division_id_confidence">
         </div>
     </div>
 {% endblock %}

--- a/templates/violation/edit-basics.html
+++ b/templates/violation/edit-basics.html
@@ -73,7 +73,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.startdate.label }}</label>
-                <input type="text" name="startdate" id="id_startdate" class="form-control" value="{{ form.instance.startdate }}">
+                <input type="text" name="startdate" id="id_startdate" class="form-control sourced" value="{{ form.instance.startdate }}">
                 {% if form.startdate.errors %}
                     {% for error in form.startdate.errors %}
                     <span class="help-block"><i class="fa fa-remove"> </i> {{error}}</span>
@@ -95,7 +95,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.enddate.label }}</label>
-                <input type="text" name="enddate" id="id_enddate" class="form-control" value="{{ form.instance.enddate }}">
+                <input type="text" name="enddate" id="id_enddate" class="form-control sourced" value="{{ form.instance.enddate }}">
                 {% if form.enddate.errors %}
                     {% for error in form.enddate.errors %}
                     <span class="help-block"><i class="fa fa-remove"> </i> {{error}}</span>
@@ -117,7 +117,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.types.label }}</label>
-                <select id="id_types" class="form-control" name="types" multiple="multiple">
+                <select id="id_types" class="form-control sourced-dropdown select2-target" name="types" multiple="multiple">
                     {% for type in form.instance.types.get_list %}
                         <option value="{{ type.get_value.id }}" selected=true>{{ type.get_value }}</option>
                     {% endfor %}
@@ -143,7 +143,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.perpetrator.label }}</label>
-                <select id="id_perpetrator" class="form-control" name="perpetrator" multiple="multiple">
+                <select id="id_perpetrator" class="form-control sourced-dropdown select2-target" name="perpetrator" multiple="multiple">
                     {% for type in form.instance.perpetrator.get_list %}
                         <option value="{{ type.get_value.value.id }}" selected=true>{{ type.get_value.value }}</option>
                     {% endfor %}
@@ -169,7 +169,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.perpetratororganization.label }}</label>
-                <select id="id_perpetratororganization" class="form-control" name="perpetratororganization" multiple="multiple">
+                <select id="id_perpetratororganization" class="form-control sourced-dropdown select2-target" name="perpetratororganization" multiple="multiple">
                     {% for type in form.instance.perpetratororganization.get_list %}
                         <option value="{{ type.get_value.value.id }}" selected=true>{{ type.get_value.value }}</option>
                     {% endfor %}
@@ -195,7 +195,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.perpetratorclassification.label }}</label>
-                <select id="id_perpetratorclassification" class="form-control" name="perpetratorclassification">
+                <select id="id_perpetratorclassification" class="form-control sourced-dropdown select2-target" name="perpetratorclassification">
                     <option value="{{ form.instance.perpetratorclassification.id }}" selected=true>
                         {{ form.instance.perpetratorclassification.get_value.value }}
                     </option>
@@ -221,7 +221,7 @@
                 <div class="form-group">
             {% endif %}
                 <label class="control-label">{{ form.division_id.label }}</label>
-                <select id="id_division_id" class="form-control" name="division_id">
+                <select id="id_division_id" class="form-control sourced-dropdown select2-target" name="division_id">
                     {% if form.instance.division_id %}
                         <option value="{{ form.instance.division_id }}">{{ form.instance.division_id|country_name }}</option>
                     {% else %}

--- a/templates/violation/edit-basics.html
+++ b/templates/violation/edit-basics.html
@@ -86,6 +86,9 @@
                 {% source_input 'startdate' source %}
             {% endfor %}
         </div>
+        <div id="id_startdate_confidence">
+            <input type="hidden" value="{{ form.instance.startdate.get_value.confidence|default_if_none:1 }}" name="startdate_confidence">
+        </div>
     </div>
     <div class="row enddate-row field-bg">
         <div class="col-sm-12">
@@ -108,6 +111,9 @@
                 {% source_input 'enddate' source %}
             {% endfor %}
         </div>
+        <div id="id_enddate_confidence">
+            <input type="hidden" value="{{ form.instance.enddate.get_value.confidence|default_if_none:1 }}" name="enddate_confidence">
+        </div>
     </div>
     <div class="row types-row field-bg">
         <div class="col-sm-12">
@@ -129,10 +135,13 @@
                 {% endif %}
             </div>
         </div>
-        <div id="id_name_source">
+        <div id="id_types_source">
             {% for source in form.instance.types.get_list.0.get_sources %}
                 {% source_input 'types' source %}
             {% endfor %}
+        </div>
+        <div id="id_types_confidence">
+            <input type="hidden" value="{{ form.instance.types.get_list.0.get_value.confidence|default_if_none:1 }}" name="types_confidence">
         </div>
     </div>
     <div class="row perpetrator-row field-bg">
@@ -156,9 +165,12 @@
             </div>
         </div>
         <div id="id_perpetrator_source">
-            {% for source in form.instance.perpetrator.get_sources %}
+            {% for source in form.instance.perpetrator.get_list.0.get_sources %}
                 {% source_input 'perpetrator' source %}
             {% endfor %}
+        </div>
+        <div id="id_perpetrator_confidence">
+            <input type="hidden" value="{{ form.instance.perpetrator.get_list.0.get_value.confidence|default_if_none:1 }}" name="perpetrator_confidence">
         </div>
     </div>
     <div class="row perpetratororganization-row field-bg">
@@ -182,9 +194,12 @@
             </div>
         </div>
         <div id="id_perpetratororganization_source">
-            {% for source in form.instance.perpetratororganization.get_sources %}
+            {% for source in form.instance.perpetratororganization.get_list.0.get_sources %}
                 {% source_input 'perpetratororganization' source %}
             {% endfor %}
+        </div>
+        <div id="id_perpetratororganization_confidence">
+            <input type="hidden" value="{{ form.instance.perpetratororganization.get_list.0.get_value.confidence|default_if_none:1 }}" name="perpetratororganization_confidence">
         </div>
     </div>
     <div class="row perpetratorclassification-row field-bg">
@@ -196,9 +211,11 @@
             {% endif %}
                 <label class="control-label">{{ form.perpetratorclassification.label }}</label>
                 <select id="id_perpetratorclassification" class="form-control sourced-dropdown select2-target" name="perpetratorclassification">
-                    <option value="{{ form.instance.perpetratorclassification.id }}" selected=true>
-                        {{ form.instance.perpetratorclassification.get_value.value }}
-                    </option>
+                    {% if form.instance.perpetratorclassification.get_value %}
+                        <option value="{{ form.instance.perpetratorclassification.get_value.value }}" selected=true>
+                            {{ form.instance.perpetratorclassification.get_value.value }}
+                        </option>
+                    {% endif %}
                 </select>
                 {% if form.perpetratorclassification.errors %}
                     {% for error in form.perpetratorclassification.errors %}
@@ -211,6 +228,9 @@
             {% for source in form.instance.perpetratorclassification.get_sources %}
                 {% source_input 'perpetratorclassification' source %}
             {% endfor %}
+        </div>
+        <div id="id_perpetratorclassification_confidence">
+            <input type="hidden" value="{{ form.instance.perpetratorclassification.get_value.confidence|default_if_none:1 }}" name="perpetratorclassification_confidence">
         </div>
     </div>
     <div class="row division_id-row field-bg">
@@ -242,6 +262,9 @@
             {% for source in form.instance.division_id.get_sources %}
                 {% source_input 'division_id' source %}
             {% endfor %}
+        </div>
+        <div id="id_division_id_confidence">
+            <input type="hidden" value="{{ form.instance.division_id.get_value.confidence|default_if_none:1 }}" name="division_id_confidence">
         </div>
     </div>
 

--- a/templates/violation/edit-locations.html
+++ b/templates/violation/edit-locations.html
@@ -154,6 +154,8 @@
         $(document).ready(function(){
             loadSources({'target': $('#id_locationdescription')});
             $('#id_location').select2({
+                allowClear: true,
+                placeholder: "{% trans 'Search for a location' %}",
                 ajax: {
                     url: "{% url 'location-autocomplete' %}?feature_type=node",
                     data: function(params){
@@ -166,6 +168,8 @@
                 minimumInputLength: 2,
             });
             $('#id_adminlevel1').select2({
+                allowClear: true,
+                placeholder: "{% trans 'Search for a location' %}",
                 ajax: {
                     url: "{% url 'location-autocomplete' %}?feature_type=relation",
                     data: function(params){
@@ -178,6 +182,8 @@
                 minimumInputLength: 2,
             });
             $('#id_adminlevel2').select2({
+                allowClear: true,
+                placeholder: "{% trans 'Search for a location' %}",
                 ajax: {
                     url: "{% url 'location-autocomplete' %}?feature_type=relation",
                     data: function(params){

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -724,7 +724,7 @@ def violation(base_violation,
             'confidence': '1',
         },
         'Violation_ViolationPerpetratorClassification': {
-            'value': classification,
+            'value': classification.value,
             'sources': access_points,
             'confidence': '1',
         }

--- a/tests/test_violation.py
+++ b/tests/test_violation.py
@@ -166,7 +166,7 @@ def test_change_perpetrator_classification(setUp,
 
     assert response.status_code == 200
 
-    new_source_ids = [s.uuid for s in new_access_points]
+    new_source_ids = [s.uuid for s in new_access_points][:-1]
 
     new_types = ['Violation against freedom from torture']
 
@@ -213,6 +213,7 @@ def test_change_perpetrator_classification(setUp,
 
     post_data = {
         'perpetratorclassification': 'More baddies',
+        'perpetratorclassification_source': new_access_points[-1].uuid,
         'description': 'Some real scary stuff',
         'description_source': new_source_ids,
     }

--- a/violation/forms.py
+++ b/violation/forms.py
@@ -38,20 +38,13 @@ class ViolationBasicsForm(BaseUpdateForm):
     description = forms.CharField(label=_("Description"))
     perpetrator = forms.ModelMultipleChoiceField(label=_("Perpetrator"), queryset=Person.objects.all(), required=False)
     perpetratororganization = forms.ModelMultipleChoiceField(label=_("Perpetrator unit"), queryset=Organization.objects.all(), required=False)
+    perpetratorclassification = forms.CharField(label=_("Perpetrator classification"), required=False)
     division_id = forms.CharField(label=_("Country"), required=False)
 
     def __init__(self, *args, **kwargs):
         violation_id = kwargs.pop('violation_id', None)
 
         super().__init__(*args, **kwargs)
-
-        self.fields['perpetratorclassification'] = GetOrCreateChoiceField(label=_("Perpetrator classification"),
-                                                                          queryset=ViolationPerpetratorClassification.objects.all(),
-                                                                          required=False,
-                                                                          object_ref_model=self._meta.model,
-                                                                          form=self,
-                                                                          field_name='perpetratorclassification',
-                                                                          object_ref_pk=violation_id)
 
         self.fields['types'] = GetOrCreateChoiceField(label=_("Violation type"),
                                                               queryset=ViolationType.objects.all(),

--- a/violation/forms.py
+++ b/violation/forms.py
@@ -74,10 +74,10 @@ class ViolationLocationsForm(BaseUpdateForm):
         ('locationdescription', ViolationLocationDescription, False),
         ('adminlevel1', ViolationAdminLevel1, False),
         ('adminlevel2', ViolationAdminLevel2, False),
-        ('location', ViolationDescription, False),
+        ('location', ViolationLocation, False),
     ]
 
     locationdescription = forms.CharField(label=_("Location Description"))
-    adminlevel1 = forms.ModelMultipleChoiceField(label=_("Settlement"), queryset=Location.objects.all(), required=False)
-    adminlevel2 = forms.ModelMultipleChoiceField(label=_("Top administrative area"), queryset=Location.objects.all(), required=False)
-    location = forms.ModelMultipleChoiceField(label=_("Exact Location"), queryset=Location.objects.all(), required=False)
+    adminlevel1 = forms.ModelChoiceField(label=_("Settlement"), queryset=Location.objects.all(), required=False)
+    adminlevel2 = forms.ModelChoiceField(label=_("Top administrative area"), queryset=Location.objects.all(), required=False)
+    location = forms.ModelChoiceField(label=_("Exact Location"), queryset=Location.objects.all(), required=False)

--- a/violation/models.py
+++ b/violation/models.py
@@ -166,6 +166,7 @@ class Violation(models.Model, BaseModel, VersionsMixin):
 
 
 @versioned
+@sourced
 class ViolationStartDate(ComplexField):
     object_ref = models.ForeignKey('Violation')
     value = ApproximateDateField(default=None, blank=True, null=True)
@@ -180,6 +181,7 @@ class ViolationFirstAllegation(ComplexField):
 
 
 @versioned
+@sourced
 class ViolationEndDate(ComplexField):
     object_ref = models.ForeignKey('Violation')
     value = ApproximateDateField(default=None, blank=True, null=True)
@@ -194,7 +196,6 @@ class ViolationLastUpdate(ComplexField):
 
 
 @translated
-@versioned
 class ViolationStatus(ComplexField):
     object_ref = models.ForeignKey('Violation')
     value = models.TextField(default=None, blank=True, null=True)
@@ -203,6 +204,7 @@ class ViolationStatus(ComplexField):
 
 @translated
 @versioned
+@sourced
 class ViolationLocationDescription(ComplexField):
     object_ref = models.ForeignKey('Violation')
     value = models.TextField(default=None, blank=True, null=True)
@@ -210,6 +212,7 @@ class ViolationLocationDescription(ComplexField):
 
 
 @versioned
+@sourced
 class ViolationAdminLevel1(ComplexField):
     object_ref = models.ForeignKey('Violation')
     value = models.ForeignKey(Location, null=True)
@@ -217,6 +220,7 @@ class ViolationAdminLevel1(ComplexField):
 
 
 @versioned
+@sourced
 class ViolationAdminLevel2(ComplexField):
     object_ref = models.ForeignKey('Violation')
     value = models.ForeignKey(Location, null=True)
@@ -238,6 +242,7 @@ class ViolationOSMId(ComplexField):
 
 
 @versioned
+@sourced
 class ViolationDivisionId(ComplexField):
     object_ref = models.ForeignKey('Violation')
     value = models.TextField(default=None, blank=True, null=True)
@@ -245,6 +250,7 @@ class ViolationDivisionId(ComplexField):
 
 
 @versioned
+@sourced
 class ViolationLocation(ComplexField):
     object_ref = models.ForeignKey('Violation')
     value = models.ForeignKey(Location, null=True)
@@ -274,6 +280,7 @@ class ViolationDescription(ComplexField):
 
 
 @versioned
+@sourced
 class ViolationPerpetrator(ComplexField):
     object_ref = models.ForeignKey('Violation')
     value = models.ForeignKey(Person, default=None, blank=True, null=True)
@@ -281,6 +288,7 @@ class ViolationPerpetrator(ComplexField):
 
 
 @versioned
+@sourced
 class ViolationPerpetratorOrganization(ComplexField):
     object_ref = models.ForeignKey('Violation')
     value = models.ForeignKey(Organization, default=None, blank=True, null=True)
@@ -289,6 +297,7 @@ class ViolationPerpetratorOrganization(ComplexField):
 
 @versioned
 @translated
+@sourced
 class ViolationType(ComplexField):
     object_ref = models.ForeignKey('Violation', null=True)
     value = models.TextField(blank=True, null=True)
@@ -297,6 +306,7 @@ class ViolationType(ComplexField):
 
 @versioned
 @translated
+@sourced
 class ViolationPerpetratorClassification(ComplexField):
     object_ref = models.ForeignKey('Violation', null=True)
     value = models.TextField(blank=True, null=True)

--- a/violation/models.py
+++ b/violation/models.py
@@ -87,7 +87,7 @@ class Violation(models.Model, BaseModel, VersionsMixin):
         self.complex_fields = [
             self.startdate, self.first_allegation, self.enddate, self.last_update,
             self.status, self.locationdescription, self.adminlevel1, self.adminlevel2,
-            self.location, self.description, self.division_id
+            self.location, self.description, self.division_id, self.perpetratorclassification
         ]
 
         self.complex_lists = [self.perpetrator, self.perpetratororganization, self.types]

--- a/violation/views.py
+++ b/violation/views.py
@@ -182,7 +182,7 @@ def violation_perpetrator_classification_autocomplete(request):
         if classification.value:
             results['results'].append({
                 'text': classification.value,
-                'id': classification.id,
+                'id': classification.value,
             })
 
     return HttpResponse(json.dumps(results), content_type='application/json')


### PR DESCRIPTION
## Overview

This PR fixes a number of related bugs on Incident create/edit forms, including:

- Save Location to the right field (#604)
- Allow saving of sources/confidences on all fields (#605)
- Properly store PerpetratorClassification as a single-value text field
- Clean up a number of stray artifacts and typos on forms

### Notes

This PR ballooned a bit from its initial scope, #604 and #605, because I found that I couldn't actually save an edited Incident in order to test those changes. The related bugfixes were necessary in order to test those changes.

## Testing Instructions

* Navigate to http://localhost:8000/en/violation/create/
* Fill out all the fields with values and sources, hit `Save`, and confirm that you created a new Incident
* Edit your incident and confirm that all the Basic fields and sources got saved properly
* Navigate to the `Locations` tab
* Add a Description, Exact Location, Settlement, and Top Administrative Area to the Incident, with a source and value for each
* Confirm that everything saves properly
