### PR TITLE
Support deleting sources and access points

### DIFF
--- a/sfm_pc/signals.py
+++ b/sfm_pc/signals.py
@@ -25,32 +25,14 @@ def update_organization_index(sender, **kwargs):
     update_index('organizations', kwargs['object_id'])
 
 
-@receiver(post_delete, sender=Organization)
-def remove_organization_index(sender, **kwargs):
-    searcher = search.Searcher()
-    searcher.delete(id=kwargs['instance'].uuid)
-
-
 @receiver(object_ref_saved, sender=Person)
 def update_person_index(sender, **kwargs):
     update_index('people', kwargs['object_id'])
 
 
-@receiver(post_delete, sender=Person)
-def remove_person_index(sender, **kwargs):
-    searcher = search.Searcher()
-    searcher.delete(id=kwargs['instance'].uuid)
-
-
 @receiver(object_ref_saved, sender=Violation)
 def update_violation_index(sender, **kwargs):
     update_index('violations', kwargs['object_id'])
-
-
-@receiver(post_delete, sender=Violation)
-def remove_violation_index(sender, **kwargs):
-    searcher = search.Searcher()
-    searcher.delete(id=kwargs['instance'].uuid)
 
 
 @receiver(object_ref_saved, sender=MembershipPerson)
@@ -75,3 +57,12 @@ def update_source_index(sender, **kwargs):
     # https://docs.djangoproject.com/en/2.2/ref/signals/#django.db.models.signals.pre_save
     instance = kwargs['instance']
     update_index('sources', str(instance.uuid))
+
+
+@receiver(post_delete, sender=Organization)
+@receiver(post_delete, sender=Person)
+@receiver(post_delete, sender=Violation)
+@receiver(post_delete, sender=Source)
+def remove_index(sender, **kwargs):
+    searcher = search.Searcher()
+    searcher.delete(id=kwargs['instance'].uuid)

--- a/source/models.py
+++ b/source/models.py
@@ -8,6 +8,7 @@ import reversion
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.urlresolvers import reverse_lazy
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -47,32 +48,31 @@ class Source(models.Model, VersionsMixin):
         from django.core.urlresolvers import reverse
         return reverse('view-source', args=[self.uuid])
 
-    def get_evidenced(self, access_point_id=None):
-        evidenced = []
-
-        for prop in dir(self):
-
-            if prop.endswith('_related'):
-                related = getattr(self, prop)
-                if access_point_id:
-                    related = related.filter(accesspoints__uuid=access_point_id)
-                related = related.all()
-
-                if related:
-
-                    for rel in related:
-                        evidenced.append(rel)
-
-        return evidenced
-
     @property
     def related_entities(self):
         """
-        Return a list of dicts of entities that are evidenced by this source.
+        Return a list of dicts representing the access points that are linked
+        to this source.
+
+        Dicts must include the following metadata:
+            - name
+            - archive_url
+            - page_number
+            - access_date
+            - url (of the Edit view for the access point)
         """
         related_entities = []
-        for access_point in self.accesspoint_set.all():
-            related_entities += access_point.related_entities
+        for point in self.accesspoint_set.all():
+            related_entities.append({
+                'name': str(point),
+                'archive_url': point.archive_url,
+                'page_number': point.page_number,
+                'accessed_on': point.accessed_on,
+                'url': reverse_lazy(
+                    'update-access-point',
+                    kwargs={'source_id': self.uuid, 'pk': point.uuid}
+                )
+            })
         return related_entities
 
     @property
@@ -133,7 +133,28 @@ class AccessPoint(models.Model, VersionsMixin):
             - field_name
             - url (a link to edit the entity)
         """
-        return []
+        related_entities = []
+
+        for prop in dir(self):
+            if prop.endswith('_related'):
+                related = getattr(self, prop).all()
+                if related:
+                    for entity in related:
+                        record_type = entity.object_ref._meta.object_name
+                        entity_metadata = {
+                            'name': str(entity),
+                            'record_type': record_type,
+                            'field_name': entity._meta.model_name.replace(record_type.lower(), '').title(),
+                            'value': entity.value,
+                            'url': None
+                        }
+                        if record_type in ['Organization', 'Person']:
+                            entity_metadata['url'] = reverse_lazy(
+                                'edit-{}'.format(record_type.lower()),
+                                args=[entity.object_ref.uuid]
+                            )
+                        related_entities.append(entity_metadata)
+        return related_entities
 
 
 def archive_source_url(source):

--- a/source/models.py
+++ b/source/models.py
@@ -66,6 +66,16 @@ class Source(models.Model, VersionsMixin):
         return evidenced
 
     @property
+    def related_entities(self):
+        """
+        Return a list of dicts of entities that are evidenced by this source.
+        """
+        related_entities = []
+        for access_point in self.accesspoint_set.all():
+            related_entities += access_point.related_entities
+        return related_entities
+
+    @property
     def revert_url(self):
         from django.core.urlresolvers import reverse
         return reverse('revert-source', args=[self.uuid])
@@ -110,6 +120,20 @@ class AccessPoint(models.Model, VersionsMixin):
             return match.group(1)
         else:
             return _('No timestamp')
+
+    @property
+    def related_entities(self):
+        """
+        Return a list of dicts of all entities that are evidenced by this
+        access point.
+
+        Dicts must have the following keys:
+            - name
+            - entity_type
+            - field_name
+            - url (a link to edit the entity)
+        """
+        return []
 
 
 def archive_source_url(source):

--- a/source/models.py
+++ b/source/models.py
@@ -148,10 +148,45 @@ class AccessPoint(models.Model, VersionsMixin):
                             'value': entity.value,
                             'url': None
                         }
-                        if record_type in ['Organization', 'Person']:
+                        # Links for top-level entities
+                        if record_type in ['Organization', 'Person', 'Violation']:
                             entity_metadata['url'] = reverse_lazy(
                                 'edit-{}'.format(record_type.lower()),
                                 args=[entity.object_ref.uuid]
+                            )
+                        # Standardized relationship links
+                        elif record_type in ['Emplacement', 'Association']:
+                            entity_metadata['url'] = reverse_lazy(
+                                'edit-organization-{}'.format(record_type.lower()),
+                                kwargs={
+                                    'organization_id': entity.object_ref.organization.get_value().value.uuid,
+                                    'pk': entity.object_ref.pk
+                                }
+                            )
+                        # Irregular relationship links
+                        elif record_type == 'Composition':
+                            entity_metadata['url'] = reverse_lazy(
+                                'edit-organization-composition',
+                                kwargs={
+                                    'organization_id': entity.object_ref.parent.get_value().value.uuid,
+                                    'pk': entity.object_ref.pk
+                                }
+                            )
+                        elif record_type == 'MembershipPerson':
+                            entity_metadata['url'] = reverse_lazy(
+                                'edit-organization-personnel',
+                                kwargs={
+                                    'organization_id': entity.object_ref.organization.get_value().value.uuid,
+                                    'pk': entity.pk
+                                }
+                            )
+                        elif record_type == 'MembershipOrganization':
+                            entity_metadata['url'] = reverse_lazy(
+                                'edit-organization-membership',
+                                kwargs={
+                                    'organization_id': entity.object_ref.organization.get_value().value.uuid,
+                                    'pk': entity.pk
+                                }
                             )
                         related_entities.append(entity_metadata)
         return related_entities

--- a/source/urls.py
+++ b/source/urls.py
@@ -1,22 +1,21 @@
 from django.conf.urls import url
 
-from source.views import get_sources, SourceCreate, source_autocomplete, \
-    SourceView, SourceEvidenceView, SourceUpdate, SourceRevertView, StashSourceView, \
-    AccessPointUpdate, AccessPointCreate, AccessPointDetail, get_citation, \
-    publication_autocomplete
+from source import views
 
 urlpatterns = [
-    url(r'^get/$', get_sources, name="get-sources"),
-    url(r'^create/$', SourceCreate.as_view(), name="create-source"),
-    url(r'^update/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', SourceUpdate.as_view(), name="update-source"),
-    url(r'^update-access-point/(?P<source_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', AccessPointUpdate.as_view(), name="update-access-point"),
-    url(r'^add-access-point/(?P<source_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', AccessPointCreate.as_view(), name="add-access-point"),
-    url(r'^view-access-point/(?P<source_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', AccessPointDetail.as_view(), name="view-access-point"),
-    url(r'^view/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', SourceView.as_view(), name="view-source"),
-    url(r'^view/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/(?P<access_point_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', SourceEvidenceView.as_view(), name="view-source-with-evidence"),
-    url(r'^revert/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', SourceRevertView.as_view(), name="revert-source"),
-    url(r'^autocomplete/$', source_autocomplete, name="source-autocomplete"),
-    url(r'^stash/$', StashSourceView.as_view(), name="stash-source"),
-    url(r'^get-citation/$', get_citation, name="get-citation"),
-    url(r'^publication/autocomplete/$', publication_autocomplete, name="publications-autocomplete"),
+    url(r'^get/$', views.get_sources, name="get-sources"),
+    url(r'^create/$', views.SourceCreate.as_view(), name="create-source"),
+    url(r'^update/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', views.SourceUpdate.as_view(), name="update-source"),
+    url(r'^update-access-point/(?P<source_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', views.AccessPointUpdate.as_view(), name="update-access-point"),
+    url(r'^add-access-point/(?P<source_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', views.AccessPointCreate.as_view(), name="add-access-point"),
+    url(r'^view-access-point/(?P<source_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', views.AccessPointDetail.as_view(), name="view-access-point"),
+    url(r'^view/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', views.SourceView.as_view(), name="view-source"),
+    url(r'^view/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/(?P<access_point_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', views.SourceEvidenceView.as_view(), name="view-source-with-evidence"),
+    url(r'^delete/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', views.SourceDeleteView.as_view(), name="delete-source"),
+    url(r'^delete/(?P<source_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', views.AccessPointDelete.as_view(), name="delete-access-point"),
+    url(r'^revert/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$', views.SourceRevertView.as_view(), name="revert-source"),
+    url(r'^autocomplete/$', views.source_autocomplete, name="source-autocomplete"),
+    url(r'^stash/$', views.StashSourceView.as_view(), name="stash-source"),
+    url(r'^get-citation/$', views.get_citation, name="get-citation"),
+    url(r'^publication/autocomplete/$', views.publication_autocomplete, name="publications-autocomplete"),
 ]

--- a/source/views.py
+++ b/source/views.py
@@ -88,6 +88,7 @@ class SourceEditView(LoginRequiredMixin, RevisionMixin):
 class SourceUpdate(SourceEditView, UpdateView):
     pass
 
+
 class SourceCreate(SourceEditView, CreateView):
     fields = [
         'title',
@@ -203,11 +204,13 @@ class AccessPointDelete(BaseDeleteView):
 
     def get_cancel_url(self):
         return reverse_lazy('view-access-point', kwargs={
-            'source_id': self.object.source.uuid,
+            'source_id': self.kwargs['source_id'],
         })
 
     def get_success_url(self):
-        return reverse('search') + '?entity_type=Source'
+        return reverse_lazy('view-access-point', kwargs={
+            'source_id': self.kwargs['source_id'],
+        })
 
     def get_related_entities(self):
         return self.object.related_entities

--- a/templates/partials/related_entities.html
+++ b/templates/partials/related_entities.html
@@ -1,9 +1,10 @@
 {% load i18n %}
 <div class="row">
     <div class="col-sm-12">
-        <h3>{% trans "Related entities" %}</h3>
+        {% block tabletitle %}<h3>{% trans "Related entities" %}</h3>{% endblock %}
         <table class="table table-condensed">
             <thead>
+            {% block tableheader %}
                 <tr>
                     <th>{% trans "Entity" %}</th>
                     <th>{% trans "Entity type" %}</th>
@@ -11,8 +12,10 @@
                     <th>{% trans "End date" %}</th>
                     <th>{% trans "Open ended" %}</th>
                 </tr>
+            {% endblock %}
             </thead>
             <tbody>
+            {% block tablebody %}
                 {% for entity in related_entities %}
                     <tr>
                         <td>
@@ -32,6 +35,7 @@
                         </td>
                     </tr>
                 {% endfor %}
+            {% endblock %}
             </tbody>
         </table>
     </div>

--- a/templates/source/access-points.html
+++ b/templates/source/access-points.html
@@ -26,6 +26,7 @@
                     <th>{% trans "Page(s)" %}</th>
                     <th>{% trans "Access Date" %}</th>
                     <th></th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody>
@@ -40,17 +41,22 @@
                                 {{ access_point.archive_url }}
                             </a>
                         </td>
-                        <td>{{ access_point.page_number }}</td>
-                        <td>{{ access_point.accessed_on }}</td>
+                        <td>{{ access_point.page_number|default_if_none:"" }}</td>
+                        <td>{{ access_point.accessed_on|default_if_none:"" }}</td>
                         <td>
                             <a href="{% url 'update-access-point' source.uuid access_point.uuid %}">
                                 <i class="fa fa-pencil"> </i> {% trans "Edit" %}
                             </a>
                         </td>
+                        <td>
+                            <a href="{% url 'delete-access-point' source.uuid access_point.uuid %}">
+                                <i class="fa fa-times"> </i> {% trans "Delete" %}
+                            </a>
+                        </td>
                     </tr>
                 {% endfor %}
                 <tr>
-                    <td colspan="4">
+                    <td colspan="5">
                         <a href="{% url 'add-access-point' source.uuid %}">
                             <i class="fa fa-plus"></i> {% trans "Add Access Point" %}
                         </a>
@@ -119,11 +125,15 @@
             <div class="form-group">
                 <div class="col-sm-12 text-right">
                     <br />
-                    <a href="{% url 'view-access-point' source.uuid %}" class="btn btn-danger">
-                        {% trans "Cancel" %}  <i class="fas fa-times"></i>
+                    {% if object.uuid %}
+                        <a href="{% url 'delete-access-point' source.uuid object.uuid %}" class="btn btn-danger">
+                            {% trans "Delete" %}
+                        </a>
+                    {% endif %}
+                    <a href="{% url 'view-access-point' source.uuid %}" class="btn btn-default">
+                        {% trans "Cancel" %}
                       </a>
-                    </button>
-                    <button type="submit" class="btn btn-success">{% trans "Save" %}  <i class="fa fa-check"></i></button>
+                    <button type="submit" class="btn btn-success">{% trans "Save" %}</button>
                 </div>
             </div>
         </form>

--- a/templates/source/delete-access-point.html
+++ b/templates/source/delete-access-point.html
@@ -1,0 +1,45 @@
+{% extends "base_delete.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block delete_header %}
+    {% blocktrans %}
+        Do you really want to remove the access point <strong>{{ object }}</strong>?
+    {% endblocktrans %}
+{% endblock %}
+
+{% block metadata_table %}
+<table class="table">
+    <tbody>
+        <tr>
+            <td><b>{% trans "Source" %}</b></td>
+            <td>{{ object.source }}</td>
+        </tr>
+        {% if object.archive_url %}
+        <tr>
+            <td><b>{% trans "Archive URL" %}</b></td>
+            <td><a href="{{ object.archive_url }}">{{ object.archive_url }}</a></td>
+        </tr>
+        {% endif %}
+        {% if object.page_number %}
+        <tr>
+            <td><b>{% trans "Page number" %}</b></td>
+            <td>{{ object.page_number }}</td>
+        </tr>
+        {% endif %}
+        {% if object.accessed_on %}
+        <tr>
+            <td><b>{% trans "Accessed on" %}</b></td>
+            <td>{{ object.accessed_on }}</td>
+        </tr>
+        {% endif %}
+    </tbody>
+</table>
+{% endblock %}
+
+{% block related_entities_table %}
+    {% if related_entities %}
+        <h3>{% trans "Related entities" %}</h3>
+        {% include 'source/partials/access_point_related_entities.html' %}
+    {% endif %}
+{% endblock %}

--- a/templates/source/delete.html
+++ b/templates/source/delete.html
@@ -1,0 +1,51 @@
+{% extends "base_delete.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block delete_header %}
+    {% blocktrans %}
+        Do you really want to remove this source?
+    {% endblocktrans %}
+{% endblock %}
+
+{% block metadata_table %}
+<table class="table">
+    <tbody>
+        <tr>
+            <td><b>{% trans "Title" %}</b></td>
+            <td>{{ object.title }}</td>
+        </tr>
+        {% if object.publication %}
+        <tr>
+            <td><b>{% trans "Publication" %}</b></td>
+            <td>{{ object.publication }}</td>
+        </tr>
+        {% endif %}
+        {% if object.publication_country %}
+        <tr>
+            <td><b>{% trans "Publication country" %}</b></td>
+            <td>{{ object.publication_country }}</td>
+        </tr>
+        {% endif %}
+        {% if object.published_on %}
+        <tr>
+            <td><b>{% trans "Published on" %}</b></td>
+            <td>{{ object.published_on }}</td>
+        </tr>
+        {% endif %}
+        {% if object.source_url %}
+        <tr>
+            <td><b>{% trans "Source URL" %}</b></td>
+            <td><a href="{{ object.source_url}}">{{ object.source_url }}</a></td>
+        </tr>
+        {% endif %}
+    </tbody>
+</table>
+{% endblock %}
+
+{% block related_entities_table %}
+    {% if related_entities %}
+        <h3>Related entities</h3>
+        {% include "source/partials/source_related_entities.html" %}
+    {% endif %}
+{% endblock %}

--- a/templates/source/edit.html
+++ b/templates/source/edit.html
@@ -122,15 +122,17 @@
             <div class="form-group">
                 <div class="col-sm-12 text-right">
                     <br />
-                      {% if source.uuid %}
-                          <a href="{% url 'view-source' source.uuid %}" class="btn btn-danger">
-                      {% else %}
-                          <a href="{% url 'search' %}?entity_type=Source" class="btn btn-danger">
-                      {% endif %}
-                      {% trans "Cancel" %}  <i class="fas fa-times"></i>
-                      </a>
-                    </button>
-                    <button type="submit" class="btn btn-success">{% trans "Save" %}  <i class="fa fa-check"></i></button>
+                    {% if source.uuid %}
+                        <a href="{% url 'delete-source' source.uuid %}" class="btn btn-danger">
+                            {% trans "Delete" %}
+                        </a>
+                        <a href="{% url 'view-source' source.uuid %}" class="btn btn-default">
+                    {% else %}
+                        <a href="{% url 'search' %}?entity_type=Source" class="btn btn-default">
+                    {% endif %}
+                        {% trans "Cancel" %}
+                    </a>
+                    <button type="submit" class="btn btn-success">{% trans "Save" %}</button>
                 </div>
             </div>
         </form>

--- a/templates/source/partials/access_point_related_entities.html
+++ b/templates/source/partials/access_point_related_entities.html
@@ -1,0 +1,32 @@
+{% extends "partials/related_entities.html" %}
+{% load i18n %}
+
+{% block tabletitle %}{% endblock %}
+
+{% block tableheader %}
+<tr>
+    <th>{% trans "Record Name" %}</th>
+    <th>{% trans "Record Type" %}</th>
+    <th>{% trans "Fieldname" %}</th>
+    <th>{% trans "Value" context "of a database record" %}</th>
+</tr>
+{% endblock %}
+
+{% block tablebody %}
+{% for entity in related_entities %}
+    <tr>
+        <td>{{ entity.name }}</td>
+        <td>
+            {% if entity.url %}
+                <a href="{{ entity.url }}">
+            {% endif %}
+                {{ entity.record_type }}
+            {% if entity.url %}
+                </a>
+            {% endif %}
+        </td>
+        <td>{{ entity.field_name }}</td>
+        <td>{{ entity.value }}</td>
+    </tr>
+{% endfor %}
+{% endblock %}

--- a/templates/source/partials/source_related_entities.html
+++ b/templates/source/partials/source_related_entities.html
@@ -1,0 +1,28 @@
+{% extends "partials/related_entities.html" %}
+{% load i18n %}
+
+{% block tabletitle %}{% endblock %}
+
+{% block tableheader %}
+<tr>
+    <th>{% trans "Access point" %}</th>
+    <th>{% trans "Archive URL" %}</th>
+    <th>{% trans "Page number" %}</th>
+    <th>{% trans "Accessed on" %}</th>
+</tr>
+{% endblock %}
+
+{% block tablebody %}
+{% for entity in related_entities %}
+    <tr>
+        <td><a href="{{ entity.url }}">{{ entity.name }}</a></td>
+        <td>
+            {% if entity.archive_url %}
+                <a href="{{ entity.archive_url }}">{{ entity.archive_url }}</a>
+            {% endif %}
+        </td>
+        <td>{{ entity.page_number|default_if_none:"" }}</td>
+        <td>{{ entity.accessed_on|default_if_none:"" }}</td>
+    </tr>
+{% endfor %}
+{% endblock %}

--- a/templates/source/view.html
+++ b/templates/source/view.html
@@ -45,7 +45,7 @@
             <form>
                 <div class="form-group">
                     <label for="access-point">
-                        {% trans "Select an access point to view records evidenced by this source:" %}
+                        {% trans "Select an access point to view entities evidenced by this source:" %}
                     </label>
                     <select id="access-point" class="form-control">
                         <option></option>
@@ -74,45 +74,16 @@
 <div class="row">
     <div class="col-sm-12">
         <h3>
-        {% blocktrans with access_point.archive_url as archive_url%}
+        {% blocktrans with archive_url=access_point.archive_url %}
             Access point <a href="{{ archive_url }}">{{ access_point }}</a>
-            evidences the following records:
+            evidences the following entities:
         {% endblocktrans %}
         </h3>
-        <table class="table table-striped">
-            <thead>
-                <tr>
-                    <th>{% trans "Record Name" %}</th>
-                    <th>{% trans "Record Type" %}</th>
-                    <th>{% trans "Fieldname" %}</th>
-                    <th>{% trans "Value" context "of a database record" %}</th>
-                </tr>
-            </thead>
-            <tbody>
-            {% if evidenced %}
-                {% for name, type, fieldname, value, link in evidenced %}
-                    <tr>
-                        <td>{{ name }}</td>
-                        <td>
-                            {% if link %}
-                                <a href="{{ link }}">
-                            {% endif %}
-                                {{ type }}
-                            {% if link %}
-                                </a>
-                            {% endif %}
-                        </td>
-                        <td>{{ fieldname }}</td>
-                        <td>{{ value }}</td>
-                    </tr>
-                {% endfor %}
-            {% else %}
-                <tr>
-                    <td>{% trans "No records found for this access point." %}</td>
-                </tr>
-            {% endif %}
-            </tbody>
-        </table>
+        <br/>
+        {% include "source/partials/related_entities.html" %}
+        {% if not related_entities %}
+            <p><i>{% trans "No entities found for this access point." %}</i></p>
+        {% endif %}
     </div>
 </div>
 {% endif %}

--- a/templates/source/view.html
+++ b/templates/source/view.html
@@ -80,7 +80,7 @@
         {% endblocktrans %}
         </h3>
         <br/>
-        {% include "source/partials/related_entities.html" %}
+        {% include "source/partials/access_point_related_entities.html" %}
         {% if not related_entities %}
             <p><i>{% trans "No entities found for this access point." %}</i></p>
         {% endif %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,8 +228,6 @@ def organizations(base_organizations,
             },
             'Organization_OrganizationOpenEnded': {
                 'value': 'Y',
-                'sources': access_points,
-                'confidence': '2',
             }
         }
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -13,6 +13,7 @@ from django.db.models import Count
 
 from reversion.models import Version
 
+from sfm_pc.templatetags.countries import country_name
 from source.models import Source, AccessPoint
 from person.models import Person
 
@@ -177,3 +178,67 @@ def test_view_source_with_no_evidence(setUp, sources):
     response = setUp.get(url)
     assert response.status_code == 200
     assert 'No access points found' in response.content.decode('utf-8')
+
+
+@pytest.fixture
+def expected_entity_values(organizations):
+    expected_entity_names = []
+    for org in organizations:
+        expected_entity_names += [
+            org.name.get_value().value,
+            country_name(org.division_id),
+            str(org.firstciteddate.get_value()),
+            str(org.lastciteddate.get_value()),
+            org.open_ended.get_value().value,
+        ] + [
+            alias.get_value().value for alias in org.aliases.get_list()
+        ] + [
+            classification.get_value().value for classification in org.classification.get_list()
+        ]
+    return expected_entity_names
+
+
+@pytest.mark.django_db
+def test_source_related_entities(setUp, sources, expected_entity_values):
+    source = sources[0]
+    related_entities = source.related_entities
+    assert len(related_entities) == len(expected_entity_values)
+    assert set([entity['value'] for entity in related_entities]) == set(expected_entity_values)
+
+
+@pytest.mark.django_db
+def test_delete_source(setUp, sources):
+    pytest.fail()
+
+
+@pytest.mark.django_db
+def test_delete_source_view_no_related_entities(setUp, sources):
+    pytest.fail()
+
+
+@pytest.mark.django_db
+def test_delete_source_view_with_related_entities(setUp, sources):
+    pytest.fail()
+
+
+@pytest.mark.django_db
+def test_access_point_related_entities(setUp, access_points, expected_entity_values):
+    access_point = access_points[0]
+    related_entities = access_point.related_entities
+    assert len(related_entities) == len(expected_entity_values)
+    assert set([entity['value'] for entity in related_entities]) == set(expected_entity_values)
+
+
+@pytest.mark.django_db
+def test_delete_access_point(setUp, sources):
+    pytest.fail()
+
+
+@pytest.mark.django_db
+def test_delete_access_point_view_no_related_entities(setUp, sources):
+    pytest.fail()
+
+
+@pytest.mark.django_db
+def test_delete_access_point_view_with_related_entities(setUp, sources):
+    pytest.fail()

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -13,7 +13,6 @@ from django.db.models import Count
 
 from reversion.models import Version
 
-from sfm_pc.templatetags.countries import country_name
 from source.models import Source, AccessPoint
 from person.models import Person
 
@@ -168,7 +167,7 @@ def test_view_source_with_evidence(setUp, sources, access_points):
     url = reverse_lazy('view-source-with-evidence', args=[source.uuid, access_point.uuid])
     response = setUp.get(url)
     assert response.status_code == 200
-    assert 'evidences the following records:' in response.content.decode('utf-8')
+    assert 'evidences the following entities:' in response.content.decode('utf-8')
 
 
 @pytest.mark.django_db
@@ -181,44 +180,66 @@ def test_view_source_with_no_evidence(setUp, sources):
 
 
 @pytest.fixture
+def expected_access_points(setUp, sources):
+    source = sources[0]
+    return source.accesspoint_set.all()
+
+
+@pytest.mark.django_db
+def test_delete_source(setUp, sources, searcher_mock, mocker):
+    source = sources[0]
+    url = reverse_lazy('delete-source', args=[source.uuid])
+    response = setUp.post(url)
+
+    assert response.status_code == 302
+
+    with pytest.raises(Source.DoesNotExist):
+        Source.objects.get(uuid=source.uuid)
+
+    searcher_mock.assert_called_once()
+    searcher_mock.assert_has_calls([mocker.call(mocker.ANY, source.uuid)])
+
+
+@pytest.mark.django_db
+def test_delete_source_view_no_related_entities(setUp, sources):
+    source = sources[0]
+    url = reverse_lazy('delete-source', args=[source.uuid])
+    response = setUp.get(url)
+    assert response.status_code == 200
+    # Make sure no related entities are rendered on the page.
+    assert 'Related entities' not in response.content.decode('utf-8')
+    # Make sure that the confirm button is enabled.
+    assert 'disabled' not in response.content.decode('utf-8')
+
+
+@pytest.mark.django_db
+def test_delete_source_view_with_related_entities(setUp, sources, access_points, expected_access_points):
+    source = sources[0]
+    url = reverse_lazy('delete-source', args=[source.uuid])
+    response = setUp.get(url)
+    assert response.status_code == 200
+    # Make sure all the related entities are rendered on the page.
+    for entity in expected_access_points:
+        assert str(entity) in response.content.decode('utf-8')
+    # Make sure that the confirm button is disabled.
+    assert 'value="Confirm" disabled' in response.content.decode('utf-8')
+
+
+@pytest.fixture
 def expected_entity_values(organizations):
-    expected_entity_names = []
+    expected_entity_values = []
     for org in organizations:
-        expected_entity_names += [
+        expected_entity_values += [
             org.name.get_value().value,
-            country_name(org.division_id),
-            str(org.firstciteddate.get_value()),
-            str(org.lastciteddate.get_value()),
-            org.open_ended.get_value().value,
+            org.division_id.get_value().value,
+            org.firstciteddate.get_value().value,
+            org.lastciteddate.get_value().value,
         ] + [
             alias.get_value().value for alias in org.aliases.get_list()
         ] + [
             classification.get_value().value for classification in org.classification.get_list()
         ]
-    return expected_entity_names
-
-
-@pytest.mark.django_db
-def test_source_related_entities(setUp, sources, expected_entity_values):
-    source = sources[0]
-    related_entities = source.related_entities
-    assert len(related_entities) == len(expected_entity_values)
-    assert set([entity['value'] for entity in related_entities]) == set(expected_entity_values)
-
-
-@pytest.mark.django_db
-def test_delete_source(setUp, sources):
-    pytest.fail()
-
-
-@pytest.mark.django_db
-def test_delete_source_view_no_related_entities(setUp, sources):
-    pytest.fail()
-
-
-@pytest.mark.django_db
-def test_delete_source_view_with_related_entities(setUp, sources):
-    pytest.fail()
+    return expected_entity_values
 
 
 @pytest.mark.django_db
@@ -226,19 +247,46 @@ def test_access_point_related_entities(setUp, access_points, expected_entity_val
     access_point = access_points[0]
     related_entities = access_point.related_entities
     assert len(related_entities) == len(expected_entity_values)
-    assert set([entity['value'] for entity in related_entities]) == set(expected_entity_values)
+    # Some related entity values are not hashable, so compare lists instead of sets
+    related_entity_values = [entity['value'] for entity in related_entities]
+    for entity in related_entity_values:
+        assert entity in expected_entity_values
 
 
 @pytest.mark.django_db
-def test_delete_access_point(setUp, sources):
-    pytest.fail()
+def test_delete_access_point(setUp, access_points, searcher_mock, mocker):
+    access_point = access_points[0]
+    url = reverse_lazy('delete-access-point', args=[access_point.source.uuid, access_point.uuid])
+    response = setUp.post(url)
+
+    assert response.status_code == 302
+
+    with pytest.raises(AccessPoint.DoesNotExist):
+        AccessPoint.objects.get(uuid=access_point.uuid)
+
+    searcher_mock.assert_not_called()
 
 
 @pytest.mark.django_db
-def test_delete_access_point_view_no_related_entities(setUp, sources):
-    pytest.fail()
+def test_delete_access_point_view_no_related_entities(setUp, access_points):
+    access_point = access_points[0]
+    url = reverse_lazy('delete-access-point', args=[access_point.source.uuid, access_point.uuid])
+    response = setUp.get(url)
+    assert response.status_code == 200
+    # Make sure no related entities are rendered on the page.
+    assert 'Related entities' not in response.content.decode('utf-8')
+    # Make sure that the confirm button is enabled.
+    assert 'disabled' not in response.content.decode('utf-8')
 
 
 @pytest.mark.django_db
-def test_delete_access_point_view_with_related_entities(setUp, sources):
-    pytest.fail()
+def test_delete_access_point_view_with_related_entities(setUp, access_points, expected_entity_values):
+    access_point = access_points[0]
+    url = reverse_lazy('delete-access-point', args=[access_point.source.uuid, access_point.uuid])
+    response = setUp.get(url)
+    assert response.status_code == 200
+    # Make sure all the related entities are rendered on the page.
+    for entity_value in expected_entity_values:
+        assert str(entity_value) in response.content.decode('utf-8')
+    # Make sure that the confirm button is disabled.
+    assert 'value="Confirm" disabled' in response.content.decode('utf-8')


### PR DESCRIPTION
## Overview

Implement "hard delete" views for sources and access points based on the spec laid out in #420.

Connects #576, #577.

## Testing Instructions

* Navigate to http://localhost:8000/en/source/create/ and create a test source
* Navigate to http://localhost:8000/en/search/?entity_type=Source and confirm your test source shows up in the search results
* Edit your test source and add a test access point
* Try to delete your test source and confirm you see a page preventing you from deleting it until you've deleted all its access points
* Navigate to any edit view for any entity and add your test access point as a source to a record in the database
* Navigate to the edit view for your test access point, try to delete it, and confirm that you're prevented from deleting it until you've removed it from the record you just edited
* Remove your test access point from the record you edited and confirm you can delete your test access point
* Confirm you can delete your test source
* Navigate to http://localhost:8000/en/search/?entity_type=Source and confirm your test source does not show up in the search results
