### PR TITLE
Refactor save urls for organizations

### DIFF
--- a/organization/views.py
+++ b/organization/views.py
@@ -201,11 +201,17 @@ class OrganizationCreateView(BaseCreateView):
     def get_success_url(self):
         organization_id = self.kwargs['organization_id']
 
-        # when saving and continuing, always return to the page we were on
+        # when saving and continuing, redirect to the edit view for the new object
         if self.request.POST.get('_continue'):
-            return self.request.path
+            if not hasattr(self, 'edit_url_name'):
+                return reverse('view-organization', args=[organization_id])
+            else:
+                return reverse(self.edit_url_name, kwargs={
+                    'organization_id': organization_id,
+                    'pk': self.object.pk
+                })
         else:
-            return reverse('view-organization', kwargs={'slug': organization_id})
+            return reverse('view-organization', args=[organization_id])
 
     def get_cancel_url(self):
         return reverse('view-organization', kwargs={'slug': self.kwargs['organization_id']})
@@ -266,10 +272,16 @@ class OrganizationCreateBasicsView(OrganizationCreateView):
     template_name = 'organization/create-basics.html'
     form_class = OrganizationCreateBasicsForm
 
-    def form_valid(self, form):
-        form.save(commit=True)
-        return HttpResponseRedirect(reverse('view-organization',
-                                    kwargs={'slug': form.object_ref.uuid}))
+    def get_success_url(self):
+        """
+        OrganizationCreateBasicsView follows a different success_url pattern than
+        the rest of the views that inherit from OrganizationCreateView, so
+        override get_success_url().
+        """
+        if self.request.POST.get('_continue'):
+            return reverse('edit-organization', args=[self.object.uuid])
+        else:
+            return reverse('view-organization', args=[self.object.uuid])
 
     # When cancelling the creation of a new organization, take the 
     # user back to the search page for organizations
@@ -304,6 +316,7 @@ class OrganizationCreateCompositionView(EditButtonsMixin, OrganizationCreateView
     context_object_name = 'current_composition'
     slug_field_kwarg = 'pk'
     button = 'relationships'
+    edit_url_name = 'edit-organization-composition'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -373,6 +386,7 @@ class OrganizationCreateMembershipView(EditButtonsMixin, OrganizationCreateView)
     context_object_name = 'current_membership'
     slug_field_kwarg = 'pk'
     button = 'relationships'
+    edit_url_name = 'edit-organization-membership'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -447,6 +461,7 @@ class OrganizationCreatePersonnelView(EditButtonsMixin, OrganizationCreateView):
     context_object_name = 'current_membership'
     slug_field_kwarg = 'organization_id'
     button = 'personnel'
+    edit_url_name = 'edit-organization-personnel'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -521,6 +536,7 @@ class OrganizationCreateEmplacementView(EditButtonsMixin, OrganizationCreateView
     form_class = OrganizationCreateEmplacementForm
     slug_field_kwarg = 'pk'
     button = 'location'
+    edit_url_name = 'edit-organization-emplacement'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -579,6 +595,7 @@ class OrganizationCreateAssociationView(EditButtonsMixin, OrganizationCreateView
     form_class = OrganizationCreateAssociationForm
     slug_field_kwarg = 'pk'
     button = 'location'
+    edit_url_name = 'edit-organization-association'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/organization/views.py
+++ b/organization/views.py
@@ -184,8 +184,13 @@ class OrganizationEditView(EditButtonsMixin, BaseUpdateView):
         return Organization.objects.get(uuid=self.kwargs['organization_id'])
 
     def get_success_url(self):
-        uuid = self.kwargs[self.slug_field_kwarg]
-        return reverse('view-organization', kwargs={'slug': uuid})
+        organization_id = self.kwargs['organization_id']
+
+        # when saving and continuing, always return to the page we were on
+        if self.request.POST.get('_continue'):
+            return self.request.path
+        else:
+            return reverse('view-organization', kwargs={'slug': organization_id})
 
     def get_cancel_url(self):
         return reverse('view-organization', kwargs={'slug': self.kwargs['organization_id']})
@@ -193,11 +198,24 @@ class OrganizationEditView(EditButtonsMixin, BaseUpdateView):
 
 class OrganizationCreateView(BaseCreateView):
 
+    def get_success_url(self):
+        organization_id = self.kwargs['organization_id']
+
+        # when saving and continuing, always return to the page we were on
+        if self.request.POST.get('_continue'):
+            return self.request.path
+        else:
+            return reverse('view-organization', kwargs={'slug': organization_id})
+
     def get_cancel_url(self):
         return reverse('view-organization', kwargs={'slug': self.kwargs['organization_id']})
 
 
 class OrganizationDeleteRelationshipView(BaseDeleteRelationshipView):
+
+    def get_success_url(self):
+        return reverse('create-organization-{}'.format(self.model.__name__.lower()),
+                        kwargs={'organization_id': self.kwargs['organization_id']})
 
     def get_cancel_url(self):
         organization_id = self.kwargs['organization_id']
@@ -234,14 +252,6 @@ class OrganizationEditBasicsView(OrganizationEditView):
         context = super().get_context_data(**kwargs)
         return context
 
-    def get_success_url(self):
-        organization_id = self.kwargs[self.slug_field_kwarg]
-
-        if self.request.POST.get('_continue'):
-            return reverse('edit-organization', kwargs={'organization_id': organization_id})
-        else:
-            return super().get_success_url()
-
     def get_form_kwargs(self):
         form_kwargs = super().get_form_kwargs()
         form_kwargs['organization_id'] = self.kwargs['organization_id']
@@ -260,14 +270,6 @@ class OrganizationCreateBasicsView(OrganizationCreateView):
         form.save(commit=True)
         return HttpResponseRedirect(reverse('view-organization',
                                     kwargs={'slug': form.object_ref.uuid}))
-
-    def get_success_url(self):
-        # This method doesn't ever really get called but since Django does not
-        # seem to recognize when we place a get_absolute_url method on the model
-        # and some way of determining where to redirect after the form is saved
-        # is required, here ya go. The redirect actually gets handled in the
-        # form_valid method above.
-        return '{}?entity_type=Organization'.format(reverse('search'))
 
     # When cancelling the creation of a new organization, take the 
     # user back to the search page for organizations
@@ -294,17 +296,6 @@ class OrganizationEditCompositionView(OrganizationEditView):
 
         return context
 
-    def get_success_url(self):
-        organization_id = self.kwargs['organization_id']
-        pk = self.kwargs['pk']
-
-        if self.request.POST.get('_continue'):
-            return reverse('edit-organization-composition',
-                           kwargs={'organization_id': organization_id,
-                                   'pk': pk})
-        else:
-            return reverse('view-organization', kwargs={'slug': organization_id})
-
 
 class OrganizationCreateCompositionView(EditButtonsMixin, OrganizationCreateView):
     template_name = 'organization/create-composition.html'
@@ -326,9 +317,6 @@ class OrganizationCreateCompositionView(EditButtonsMixin, OrganizationCreateView
 
         return context
 
-    def get_success_url(self):
-        return reverse('edit-organization', kwargs={'organization_id': self.kwargs['organization_id']})
-
 
 class OrganizationDeleteCompositionView(OrganizationDeleteRelationshipView):
     model = Composition
@@ -340,9 +328,6 @@ class OrganizationDeleteCompositionView(OrganizationDeleteRelationshipView):
         parent = composition.parent.get_value().value
         child = composition.child.get_value().value
         return parent, child
-
-    def get_success_url(self):
-        return reverse('view-organization', kwargs={'slug': self.kwargs['organization_id']})
 
     def delete(self, request, *args, **kwargs):
         parent, child = self.get_objects_to_update()
@@ -380,17 +365,6 @@ class OrganizationEditMembershipView(OrganizationEditView):
         form_kwargs['organization_id'] = self.kwargs['organization_id']
         return form_kwargs
 
-    def get_success_url(self):
-        organization_id = self.kwargs['organization_id']
-        pk = self.kwargs['pk']
-
-        if self.request.POST.get('_continue'):
-            return reverse('edit-organization-membership',
-                           kwargs={'organization_id': organization_id,
-                                   'pk': pk})
-        else:
-            return reverse('view-organization', kwargs={'slug': organization_id})
-
 
 class OrganizationCreateMembershipView(EditButtonsMixin, OrganizationCreateView):
     template_name = 'organization/create-membership.html'
@@ -417,9 +391,6 @@ class OrganizationCreateMembershipView(EditButtonsMixin, OrganizationCreateView)
         form_kwargs['organization_id'] = self.kwargs['organization_id']
         return form_kwargs
 
-    def get_success_url(self):
-        return reverse('edit-organization', kwargs={'organization_id': self.kwargs['organization_id']})
-
 
 class OrganizationDeleteMembershipView(OrganizationDeleteRelationshipView):
     model = MembershipOrganization
@@ -431,9 +402,6 @@ class OrganizationDeleteMembershipView(OrganizationDeleteRelationshipView):
         organization = membership.organization.get_value().value
         return member, organization
 
-    def get_success_url(self):
-        return reverse('view-organization', kwargs={'slug': self.kwargs['organization_id']})
-
     def delete(self, request, *args, **kwargs):
         member, organization = self.get_objects_to_update()
 
@@ -444,7 +412,12 @@ class OrganizationDeleteMembershipView(OrganizationDeleteRelationshipView):
 
         return response
 
-    # overriding this cancel url since the model name is MembershipOrganization
+    # overriding the success and cancel urls since the model name is MembershipOrganization
+    def get_success_url(self):
+        organization_id = self.kwargs['organization_id']
+        return reverse('create-organization-membership',
+                        kwargs={'organization_id': organization_id})
+
     def get_cancel_url(self):
         organization_id = self.kwargs['organization_id']
         pk = self.kwargs['pk']
@@ -460,17 +433,6 @@ class OrganizationEditPersonnelView(OrganizationEditView):
     context_object_name = 'current_membership'
     slug_field_kwarg = 'organization_id'
     button = 'personnel'
-
-    def get_success_url(self):
-        organization_id = self.kwargs['organization_id']
-        pk = self.kwargs['pk']
-
-        if self.request.POST.get('_continue'):
-            return reverse('edit-organization-personnel',
-                           kwargs={'organization_id': organization_id,
-                                   'pk': pk})
-        else:
-            return reverse('view-organization', kwargs={'slug': organization_id})
 
     def get_form_kwargs(self):
         form_kwargs = super().get_form_kwargs()
@@ -496,9 +458,6 @@ class OrganizationCreatePersonnelView(EditButtonsMixin, OrganizationCreateView):
         form_kwargs['organization_id'] = self.kwargs['organization_id']
         return form_kwargs
 
-    def get_success_url(self):
-        return reverse('edit-organization', kwargs={'organization_id': self.kwargs['organization_id']})
-
 
 class OrganizationDeletePersonnelView(OrganizationDeleteRelationshipView):
     model = MembershipPerson
@@ -510,9 +469,6 @@ class OrganizationDeletePersonnelView(OrganizationDeleteRelationshipView):
         organization = membership.organization.get_value().value
         return person, organization
 
-    def get_success_url(self):
-        return reverse('view-organization', kwargs={'slug': self.kwargs['organization_id']})
-
     def delete(self, request, *args, **kwargs):
         person, organization = self.get_objects_to_update()
 
@@ -523,7 +479,12 @@ class OrganizationDeletePersonnelView(OrganizationDeleteRelationshipView):
 
         return response
 
-    # overriding this cancel url since the model name is MembershipPerson
+    # overriding the success and cancel urls since the model name is MembershipPerson
+    def get_success_url(self):
+        organization_id = self.kwargs['organization_id']
+        return reverse('create-organization-personnel',
+                        kwargs={'organization_id': organization_id})
+
     def get_cancel_url(self):
         organization_id = self.kwargs['organization_id']
         pk = self.kwargs['pk']
@@ -547,17 +508,6 @@ class OrganizationEditEmplacementView(OrganizationEditView):
         context['associations'] = [e.object_ref for e in context['organization'].associations]
 
         return context
-
-    def get_success_url(self):
-        organization_id = self.kwargs['organization_id']
-        pk = self.kwargs['pk']
-
-        if self.request.POST.get('_continue'):
-            return reverse('edit-organization-emplacement',
-                           kwargs={'organization_id': organization_id,
-                                   'pk': pk})
-        else:
-            return reverse('view-organization', kwargs={'slug': organization_id})
 
     def get_form_kwargs(self):
         form_kwargs = super().get_form_kwargs()
@@ -585,9 +535,6 @@ class OrganizationCreateEmplacementView(EditButtonsMixin, OrganizationCreateView
         form_kwargs['organization_id'] = self.kwargs['organization_id']
         return form_kwargs
 
-    def get_success_url(self):
-        return reverse('edit-organization', kwargs={'organization_id': self.kwargs['organization_id']})
-
 
 class OrganizationDeleteEmplacementView(OrganizationDeleteRelationshipView):
     model = Emplacement
@@ -598,9 +545,6 @@ class OrganizationDeleteEmplacementView(OrganizationDeleteRelationshipView):
         organization = emplacement.organization.get_value().value
         site = emplacement.site.get_value().value
         return organization, site
-
-    def get_success_url(self):
-        return reverse('view-organization', kwargs={'slug': self.kwargs['organization_id']})
 
     def delete(self, request, *args, **kwargs):
         organization, _ = self.get_objects_to_update()
@@ -628,17 +572,6 @@ class OrganizationEditAssociationView(OrganizationEditView):
 
         return context
 
-    def get_success_url(self):
-        organization_id = self.kwargs['organization_id']
-        pk = self.kwargs['pk']
-
-        if self.request.POST.get('_continue'):
-            return reverse('edit-organization-association',
-                           kwargs={'organization_id': organization_id,
-                                   'pk': pk})
-        else:
-            return reverse('view-organization', kwargs={'slug': organization_id})
-
 
 class OrganizationCreateAssociationView(EditButtonsMixin, OrganizationCreateView):
     model = Association
@@ -655,9 +588,6 @@ class OrganizationCreateAssociationView(EditButtonsMixin, OrganizationCreateView
 
         return context
 
-    def get_success_url(self):
-        return reverse('edit-organization', kwargs={'organization_id': self.kwargs['organization_id']})
-
 
 class OrganizationDeleteAssociationView(OrganizationDeleteRelationshipView):
     model = Association
@@ -668,9 +598,6 @@ class OrganizationDeleteAssociationView(OrganizationDeleteRelationshipView):
         organization = association.organization.get_value().value
         area = association.area.get_value().value
         return organization, area
-
-    def get_success_url(self):
-        return reverse('view-organization', kwargs={'slug': self.kwargs['organization_id']})
 
     def delete(self, request, *args, **kwargs):
         organization, _ = self.get_objects_to_update()

--- a/sfm_pc/forms.py
+++ b/sfm_pc/forms.py
@@ -411,6 +411,8 @@ class BaseUpdateForm(BaseEditForm):
 
         self.instance.object_ref_saved()
 
+        return self.instance
+
 
 class BaseCreateForm(BaseEditForm):
 
@@ -521,6 +523,8 @@ class BaseCreateForm(BaseEditForm):
             self.object_ref.update(update_info)
 
         self.object_ref.object_ref_saved()
+
+        return self.object_ref
 
 
 def division_choices():

--- a/templates/organization/edit-association.html
+++ b/templates/organization/edit-association.html
@@ -4,7 +4,7 @@
 {% load citations %}
 
 {% block form_content %}
-    <h2>{% trans "Edit Location" %}</h2>
+    <h2>{% trans "Edit area" %}</h2>
     <input type="hidden" name="organization" value="{{ form.instance.organization.get_value.value.id }}" />
     {% for source in form.instance.organization.get_sources %}
         <input type="hidden" name="organization_source" value="{{ source.uuid }}" />

--- a/templates/organization/edit-emplacement.html
+++ b/templates/organization/edit-emplacement.html
@@ -4,7 +4,7 @@
 {% load citations %}
 
 {% block form_content %}
-    <h2>{% trans "Edit Location" %}</h2>
+    <h2>{% trans "Edit site" %}</h2>
     <input type="hidden" name="organization" value="{{ form.instance.organization.get_value.value.id }}">
     {% for source in form.instance.organization.get_sources %}
         <input type="hidden" name="organization_source" value="{{ source.uuid }}" />

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -531,6 +531,7 @@ def test_edit_emplacement(save_and_continue,
     post_data = {
         'site': location_node.id,
         'site_source': new_source_ids,
+        'organization': org.id
     }
 
     if save_and_continue:
@@ -548,7 +549,7 @@ def test_edit_emplacement(save_and_continue,
     assert emp.site.get_value().value == location_node
     assert set(emp.site.get_sources()) == set(new_access_points)
 
-    fake_signal.assert_called_with(object_id=emplacement.id, sender=Emplacement)
+    fake_signal.assert_called_with(object_id=emp.id, sender=Emplacement)
 
 
 @pytest.mark.django_db
@@ -677,8 +678,8 @@ def test_organization_edit_buttons(setUp,
     org = full_organizations[0]
     composition = Composition.objects.first()
     person = org.personnel[0]
-    association = org.associations[0]
-    emplacement = org.emplacements[0]
+    association = org.associations[0].object_ref
+    emplacement = org.emplacements[0].object_ref
 
     assert is_tab_active(setUp.get(reverse_lazy('edit-organization', args=[org.uuid])),
                         'Basics')


### PR DESCRIPTION
## Overview

Sorts out the `Save` and `Save and continue` links for all organization edit views.

The logic follows what @tlongers describes in #540:

* `Cancel` should always take the user to the read-only view, disregarding all changes
* `Save` should always take the user to the read-only view, with any (valid) updates committed
* `Save and continue editing` should always commit any (valid) changes, and return the user to the screen they were working on.
* After deleting a linking record, the user should always be returned to the edit view for the sort of record they just deleted e.g. if you've deleted something from organization->postings, after a confirmed delete, return the user to organization->postings.

Connects #540 

## Testing Instructions

* For `Organizations basics` edit an organization of your choosing. Make a change and click `Save`. It should take you back to the view page for that organization. Edit it again and click `Save and continue` and it should save the changes and keep you on the same page.
* For `Relationships` and `Personnel`, create a new relationship and click `Save`. It should take you back to the view page for that organization. Edit it again and click `Save and continue`. It should keep you on the same page for you to continue adding relationships and personnel.
* For deleting, clicking `Delete` should take you back to the edit view for the type of record you just deleted.
