### PR TITLE
Correctly format AccessPoint.accessed_on in form input

### DIFF
--- a/templates/source/access-points.html
+++ b/templates/source/access-points.html
@@ -40,8 +40,8 @@
                                 {{ access_point.archive_url }}
                             </a>
                         </td>
-                        <td>{{ access_point.page_number }}</td>
-                        <td>{{ access_point.accessed_on }}</td>
+                        <td>{{ access_point.page_number|default_if_none:"" }}</td>
+                        <td>{{ access_point.accessed_on|default_if_none:"" }}</td>
                         <td>
                             <a href="{% url 'update-access-point' source.uuid access_point.uuid %}">
                                 <i class="fa fa-pencil"> </i> {% trans "Edit" %}
@@ -102,7 +102,7 @@
             {% endif %}
             <label for="id_accessed_on" class="control-label col-sm-2">{% trans "Access Date" %}</label>
                 <div class="col-sm-10">
-                    <input type="text" class="form-control datepicker" id="id_accessed_on" name="accessed_on" value="{{ form.instance.accessed_on|default_if_none:"" }}">
+                    <input type="text" class="form-control datepicker" id="id_accessed_on" name="accessed_on" value="{{ form.instance.accessed_on|date:'Y-m-d'|default_if_none:'' }}">
                 {% if form.accessed_on.errors %}
                     {% for error in form.accessed_on.errors %}
                     <span class="help-block"><i class="fa fa-remove"> </i> {{error}}</span>


### PR DESCRIPTION
## Overview

Previously, `AccessPoint.accessed_on` was being rendered as a verbose date string in the input when editing existing access points. This caused a validation error, since we don't actually support verbose date strings as inputs. Update the template to render the raw date string instead so that existing access points will validate.

Closes #618.

## Testing Instructions

* Visit http://localhost:8000/en/source/update-access-point/6c20a281-d7f5-4d46-8ca7-0307e2b47ea5/00159668-1fcc-4051-8412-752566ac89d3/
* Save the access point without editing anything
* Confirm that the form validates properly
