### PR TITLE
Ensure nav tabs are properly active on Person CRUD views

### DIFF
--- a/person/views.py
+++ b/person/views.py
@@ -341,20 +341,6 @@ class PersonEditBasicsView(PersonEditView):
         form_kwargs['person_id'] = self.kwargs['slug']
         return form_kwargs
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-
-        # If there are no memberships, we shoult make sure to go to the create
-        # view when it exists.
-        first_membership = context['person'].memberships.first()
-        if first_membership:
-            # Person.memberships() returns a QuerySet of MembershipPersonMember
-            # objects, so we need to access the object ref to get the corresponding
-            # MembershipPerson object
-            context['first_membership'] = first_membership.object_ref
-
-        return context
-
     def get_success_url(self):
         person_id = self.kwargs[self.slug_field_kwarg]
 
@@ -379,7 +365,6 @@ class PersonEditPostingsView(PersonEditView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['person'] = Person.objects.get(uuid=self.kwargs['person_id'])
-        context['first_membership'] = {'id': self.kwargs['pk']}
 
         affiliations = context['person'].memberships
         memberships = tuple(mem.object_ref for mem in affiliations)

--- a/templates/person/create-posting.html
+++ b/templates/person/create-posting.html
@@ -7,15 +7,6 @@
     <h1>{% trans "Add a posting" %}</h1>
 </div>
 {% endblock %}
-{% block edit_links %}
-    <div class="col-sm-6">
-        <h1>
-            {% trans "Edit:" %}
-            <a href="{% url 'edit-person' person.uuid %}" class="btn btn-default">{% trans "Basics" %}</a>
-            <a href="{% url 'create-person-posting' person.uuid %}" class="btn btn-primary">{% trans "Postings" %}</a>
-        </h1>
-    </div>
-{% endblock %}
 {% block form_content %}
     <h2>{% trans 'Edit postings' %}</h2>
     <input type="hidden" name="member" value="{{ person.id }}" />

--- a/templates/person/edit-basics.html
+++ b/templates/person/edit-basics.html
@@ -7,12 +7,8 @@
     <div class="col-sm-6">
         <h1>
             {% trans "Edit:" %}
-            <a href="{% url 'edit-person' person.uuid %}" class="btn btn-default">{% trans "Basics" %}</a>
-            {% if first_membership %}
-                <a href="{% url 'edit-person-postings' person.uuid first_membership.id %}" class="btn btn-primary">{% trans "Postings" %}</a>
-            {% else %}
-                <a href="{% url 'create-person-posting' person.uuid %}" class="btn btn-primary">{% trans "Postings" %}</a>
-            {% endif %}
+            <a href="{% url 'edit-person' person.uuid %}" class="btn btn-primary">{% trans "Basics" %}</a>
+            <a href="{% url 'create-person-posting' person.uuid %}" class="btn btn-default">{% trans "Postings" %}</a>
         </h1>
     </div>
 {% endblock %}

--- a/templates/person/edit-postings.html
+++ b/templates/person/edit-postings.html
@@ -18,7 +18,7 @@
         <h1>
             {% trans "Edit:" %}
             <a href="{% url 'edit-person' person.uuid %}" class="btn btn-default">{% trans "Basics" %}</a>
-            <a href="{% url 'edit-person-postings' person.uuid first_membership.id %}" class="btn btn-primary">{% trans "Postings" %}</a>
+            <a href="{% url 'create-person-posting' person.uuid %}" class="btn btn-primary">{% trans "Postings" %}</a>
         </h1>
     </div>
 {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,17 @@ from source.models import Source, AccessPoint
 from location.models import Location
 
 
+def is_tab_active(page, tab_name):
+    """
+    Determine if a nav tab with a given tab_name is active on a given page.
+    Active tabs should have the "primary" class name.
+    """
+    if 'primary">{}'.format(tab_name) in page.content.decode('utf-8'):
+        return True
+    else:
+        return False
+
+
 @pytest.fixture
 def user():
     return User.objects.create(username='testuser',

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -8,6 +8,7 @@ from organization.models import Organization, OrganizationAlias, \
     OrganizationClassification
 from source.models import AccessPoint
 from composition.models import Composition
+from tests.conftest import is_tab_active
 
 
 @pytest.fixture
@@ -260,12 +261,6 @@ def test_organization_edit_buttons(setUp,
     person = org.personnel[0]
     association = org.associations[0]
     emplacement = org.emplacements[0]
-
-    def is_tab_active(page, tab_name):
-        if 'primary">{}'.format(tab_name) in page.content.decode('utf-8'):
-            return True
-        else:
-            return False
 
     assert is_tab_active(setUp.get(reverse_lazy('edit-organization', args=[org.uuid])),
                         'Basics')

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -11,6 +11,7 @@ from source.models import AccessPoint
 from person.models import Person
 from organization.models import Organization
 from membershipperson.models import MembershipPerson, Rank, Role
+from tests.conftest import is_tab_active
 
 
 @pytest.fixture
@@ -692,3 +693,19 @@ def test_create_posting(setUp,
 
     fake_signal.assert_called_with(object_id=membership.id,
                                    sender=MembershipPerson)
+
+
+@pytest.mark.django_db
+def test_person_edit_buttons(setUp, people, membership_person):
+    assert is_tab_active(setUp.get(reverse_lazy('edit-person', args=[people[0].uuid])),
+                         'Basics')
+    assert is_tab_active(setUp.get(reverse_lazy('create-person-posting', args=[people[0].uuid])),
+                         'Postings')
+    assert is_tab_active(
+        setUp.get(
+            reverse_lazy(
+                'edit-person-postings',
+                args=[people[0].uuid, membership_person[0].pk]
+            )
+        ),
+        'Postings')


### PR DESCRIPTION
## Overview

Make sure that Person CRUD views show the correct nav tab as "active" when the user is on a corresponding page.

Connects #446.

## Testing Instructions

* Navigate to the Edit view for a person
* Ensure the `Basics` button is active
* Click on the `Postings` button
* Confirm you are taken to the CreateView for postings and ensure the `Postings` button is active
* Edit a posting
* Ensure the `Postings` button is still active
* Click on the `Basics` button
* Confirm you are taken to the EditView for Person basics and ensure the `Basics` button is active