### PR TITLE
Return user context in custom 500 error response

### DIFF
--- a/sfm_pc/urls.py
+++ b/sfm_pc/urls.py
@@ -66,3 +66,6 @@ if settings.DEBUG:
         ) + urlpatterns
     except ImportError:
         pass
+
+# Custom 500 error handler
+handler500 = 'sfm_pc.views.server_error'

--- a/sfm_pc/views.py
+++ b/sfm_pc/views.py
@@ -9,7 +9,7 @@ import csv
 
 from django.conf import settings
 from django.views.generic.base import TemplateView
-from django.http import HttpResponse, HttpResponseNotFound, Http404
+from django.http import HttpResponse, Http404, HttpResponseServerError
 from django.views.generic.edit import FormView
 from django.views.decorators.cache import never_cache
 from django.forms import formset_factory
@@ -25,6 +25,7 @@ from django.contrib.auth.models import User
 from django.views.generic.edit import CreateView, UpdateView
 from django.utils import timezone
 from django.http import StreamingHttpResponse
+from django.template import loader
 
 from reversion.models import Version, Revision
 from extra_views import FormSetView
@@ -411,3 +412,11 @@ class DumpChangeLog(FormView, VersionsMixin):
         response['Content-Disposition'] = 'attachment; filename="changelog-{}.csv"'.format(timezone.now().isoformat())
 
         return response
+
+
+def server_error(request):
+    """
+    Customize the Django 500 view to pass in user context.
+    """
+    template = loader.get_template('500.html')
+    return HttpResponseServerError(template.render(request=request))


### PR DESCRIPTION
## Overview

Django [does not return user context to the 500 error view](https://docs.djangoproject.com/en/2.2/ref/views/#the-500-server-error-view) by default, meaning that logged-in users who see a 500 error page will appear to have been logged out and will not see the page in the language they have selected. Customize the 500 error view to return user context via the `request` object, following the recommended path for [customizing error views](https://docs.djangoproject.com/en/2.2/topics/http/views/#customizing-error-views).

Connects #582.

### Notes

I took a stab at unit testing this before realizing that [our version of Django doesn't support testing custom 500 views](https://code.djangoproject.com/ticket/18707). We'll just have to test manually.

## Testing Instructions

* Start up your development environment, but don't start the search index with `docker-compose up`
* Adjust your `settings_local.py` to set the following settings for testing production errors:

```python
DEBUG = False
ALLOWED_HOSTS = ['localhost']
```

* Navigate to http://localhost:8000/ and make sure you're logged in
* Click `Search` and confirm you get shown a 500 page where you can see all of the nav items
* Navigate back to http://localhost:8000/ and select `Spanish` from the language select
* Click `Buscar` and confirm you get shown a 500 page where you can see all of the nav items
