### PR TITLE
Prevent saving sources for empty field values

### DIFF
--- a/sfm_pc/forms.py
+++ b/sfm_pc/forms.py
@@ -217,6 +217,14 @@ class BaseUpdateForm(BaseEditForm):
             else:
                 posted_sources = set()
 
+            source_required = getattr(field_instance.field_model, 'source_required', False)
+            if source_required and field in self.empty_values and posted_sources:
+                error = forms.ValidationError(
+                    _('Empty fields should not have sources'),
+                    code='invalid')
+                self.add_error(field, error)
+                continue
+
             try:
                 existing_sources = {str(s.uuid) for s in field_instance.get_sources()}
             except AttributeError:
@@ -228,7 +236,7 @@ class BaseUpdateForm(BaseEditForm):
 
             if not field in (self.empty_values | fields_with_errors):
 
-                if not getattr(field_instance.field_model, 'source_required', False):
+                if not source_required:
                     self.update_fields.add(field)
                     continue
 
@@ -436,9 +444,17 @@ class BaseCreateForm(BaseEditForm):
             else:
                 posted_sources = set()
 
+            source_required = getattr(field_model, 'source_required', False)
+            if source_required and field_name in self.empty_values and posted_sources:
+                error = forms.ValidationError(
+                    _('Empty fields should not have sources'),
+                    code='invalid')
+                self.add_error(field_name, error)
+                continue
+
             if not field_name in (self.empty_values | fields_with_errors):
 
-                if not getattr(field_model, 'source_required', False):
+                if not source_required:
                     self.update_fields.add(field_name)
                     continue
 

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -304,7 +304,6 @@ def test_remove_all_values(setUp, people, fake_signal):
     post_data = {
         'name': person.name.get_value().value,
         'name_source': sources,
-        'aliases_source': [s.uuid for s in person.aliases.get_list()[0].get_sources()]
     }
 
     response = setUp.post(reverse_lazy('edit-person', kwargs={'slug': person.uuid}), post_data)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -293,16 +293,26 @@ def test_delete_access_point_view_with_related_entities(setUp, access_points, ex
 
 
 @pytest.mark.django_db
-def test_source_with_no_value_raises_error(setUp, new_access_points, fake_signal):
+def test_source_with_no_value_raises_error(setUp, people, new_access_points, fake_signal):
     """Make sure the user can't assign a source to an empty field."""
+    # Test the CreateView.
     new_source_ids = [s.uuid for s in new_access_points]
     post_data = {
         'name': 'foo',
         'name_source': new_source_ids,
         'aliases_source': new_source_ids  # Add source field without a corresponding value
     }
-    response = setUp.post(reverse_lazy('create-person'), post_data)
-    assert response.status_code == 200
+    create_response = setUp.post(reverse_lazy('create-person'), post_data)
+    assert create_response.status_code == 200
 
-    form = response.context['form']
-    assert 'aliases' in form.errors.keys()
+    create_form = create_response.context['form']
+    assert 'aliases' in create_form.errors.keys()
+    assert 'Empty fields should not have sources' in create_form.errors['aliases']
+
+    # Test the EditView.
+    edit_response = setUp.post(reverse_lazy('edit-person', args=[people[0].uuid]), post_data)
+    assert edit_response.status_code == 200
+
+    edit_form = edit_response.context['form']
+    assert 'aliases' in edit_form.errors.keys()
+    assert 'Empty fields should not have sources' in edit_form.errors['aliases']

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -290,3 +290,19 @@ def test_delete_access_point_view_with_related_entities(setUp, access_points, ex
         assert str(entity_value) in response.content.decode('utf-8')
     # Make sure that the confirm button is disabled.
     assert 'value="Confirm" disabled' in response.content.decode('utf-8')
+
+
+@pytest.mark.django_db
+def test_source_with_no_value_raises_error(setUp, new_access_points, fake_signal):
+    """Make sure the user can't assign a source to an empty field."""
+    new_source_ids = [s.uuid for s in new_access_points]
+    post_data = {
+        'name': 'foo',
+        'name_source': new_source_ids,
+        'aliases_source': new_source_ids  # Add source field without a corresponding value
+    }
+    response = setUp.post(reverse_lazy('create-person'), post_data)
+    assert response.status_code == 200
+
+    form = response.context['form']
+    assert 'aliases' in form.errors.keys()


### PR DESCRIPTION
## Overview

Raise a ValidationError when users try to attach a source to an empty field value.

Connects #598, #627.

### Demo

The new ValidationError in action:

<img width="1080" alt="Screen Shot 2019-09-16 at 5 06 18 PM" src="https://user-images.githubusercontent.com/14170650/64996732-60b19e00-d8a4-11e9-84c0-1a8113779b3c.png">

### Notes

In #598 and #627, we discussed whether it would be better to support empty fields with sources or block them altogether. Ultimately, we decided it would be simpler and would make more sense with the research flow to prevent sourced, empty fields.

## Testing Instructions

* Navigate to http://localhost:8000/en/person/create/
* Try to save a Person with sources for Aliases but no actual Aliases
* Confirm the form raises a ValidationError
* Navigate to http://localhost:8000/en/person/edit/d91548ae-2661-4e1f-b28c-b98a30574701/
* Try to remove the value for Aliases without removing its sources
* Confirm the form raises a ValidationError
