### PR TITLE
Reconfiguring downloads

### DIFF
--- a/sfm_pc/sql/areas.sql
+++ b/sfm_pc/sql/areas.sql
@@ -1,8 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  MAX(division_id.value) AS division_id,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS country_iso,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,
@@ -15,6 +14,7 @@ SELECT
   MAX(open_ended.value) AS open_ended,
   location.id AS area_osm_id,
   MAX(location.name) AS area_name,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS area_country_iso,
   MAX(location.feature_type) AS area_osm_feature_type,
   MAX(location.adminlevel) AS area_admin_level,
   MAX(adminlevel1.id) AS admin_level_1_id,

--- a/sfm_pc/sql/areas.sql
+++ b/sfm_pc/sql/areas.sql
@@ -14,7 +14,7 @@ SELECT
   MAX(open_ended.value) AS open_ended,
   location.id AS area_osm_id,
   MAX(location.name) AS area_name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS area_country_iso,
+  substring(MAX(location.division_id), position(':' IN MAX(location.division_id)) + 1, 2) AS area_country_iso,
   MAX(location.feature_type) AS area_osm_feature_type,
   MAX(location.adminlevel) AS area_admin_level,
   MAX(adminlevel1.id) AS admin_level_1_id,

--- a/sfm_pc/sql/areas.sql
+++ b/sfm_pc/sql/areas.sql
@@ -1,7 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS org_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,

--- a/sfm_pc/sql/areas.sql
+++ b/sfm_pc/sql/areas.sql
@@ -1,7 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS org_country_iso,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS organization_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,

--- a/sfm_pc/sql/basic.sql
+++ b/sfm_pc/sql/basic.sql
@@ -1,7 +1,6 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
   substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS basic_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,

--- a/sfm_pc/sql/basic.sql
+++ b/sfm_pc/sql/basic.sql
@@ -1,8 +1,8 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  MAX(division_id.value) AS division_id,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS country_iso,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS basic_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,

--- a/sfm_pc/sql/basic.sql
+++ b/sfm_pc/sql/basic.sql
@@ -1,7 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS basic_country_iso,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS organization_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,

--- a/sfm_pc/sql/memberships.sql
+++ b/sfm_pc/sql/memberships.sql
@@ -1,8 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  MAX(division_id.value) AS division_id,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS country_iso,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,
@@ -15,6 +14,7 @@ SELECT
   MAX(open_ended.value) AS open_ended,
   member.uuid AS member_id,
   MAX(member_name.value) AS member_name,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS member_country_iso,
   MAX(member_firstciteddate.value) AS membership_start_date,
   MAX(member_lastciteddate.value) AS membership_end_date,
   CASE

--- a/sfm_pc/sql/memberships.sql
+++ b/sfm_pc/sql/memberships.sql
@@ -54,7 +54,7 @@ LEFT JOIN organization_organization AS member
   ON member_organization.value_id = member.id
 LEFT JOIN organization_organizationname AS member_name
   ON member.id = member_name.object_ref_id
-JOIN organization_organizationdivisionid as member_country
+LEFT JOIN organization_organizationdivisionid as member_country
   on member.id = member_country.object_ref_id
 LEFT JOIN membershiporganization_fcd AS member_firstciteddate
   ON member_object_ref.id = member_firstciteddate.object_ref_id

--- a/sfm_pc/sql/memberships.sql
+++ b/sfm_pc/sql/memberships.sql
@@ -1,7 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS org_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,
@@ -14,7 +14,7 @@ SELECT
   MAX(open_ended.value) AS open_ended,
   member.uuid AS member_id,
   MAX(member_name.value) AS member_name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS member_country_iso,
+  substring(MAX(member_country.value), position(':' IN MAX(member_country.value)) + 1, 2) AS member_country_iso,
   MAX(member_firstciteddate.value) AS membership_start_date,
   MAX(member_lastciteddate.value) AS membership_end_date,
   CASE
@@ -54,6 +54,8 @@ LEFT JOIN organization_organization AS member
   ON member_organization.value_id = member.id
 LEFT JOIN organization_organizationname AS member_name
   ON member.id = member_name.object_ref_id
+JOIN organization_organizationdivisionid as member_country
+  on member.id = member_country.object_ref_id
 LEFT JOIN membershiporganization_fcd AS member_firstciteddate
   ON member_object_ref.id = member_firstciteddate.object_ref_id
 LEFT JOIN membershiporganization_lcd AS member_lastciteddate

--- a/sfm_pc/sql/memberships.sql
+++ b/sfm_pc/sql/memberships.sql
@@ -1,7 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS org_country_iso,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS organization_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,

--- a/sfm_pc/sql/parentage.sql
+++ b/sfm_pc/sql/parentage.sql
@@ -1,8 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  MAX(division_id.value) AS division_id,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS country_iso,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,
@@ -14,6 +13,7 @@ SELECT
   AS start_date_of_organization,
   MAX(open_ended.value) AS open_ended,
   parent.uuid AS parent_id,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS parent_country_iso,
   MAX(parent_name.value) AS parent_name,
   array_to_string(array_agg(DISTINCT comp_classification.value), ';') AS relationship_classifications,
   MAX(comp_firstciteddate.value) AS relationship_first_cited_date,

--- a/sfm_pc/sql/parentage.sql
+++ b/sfm_pc/sql/parentage.sql
@@ -51,7 +51,7 @@ LEFT JOIN organization_organization AS parent
   ON comp_parent.value_id = parent.id
 LEFT JOIN organization_organizationname AS parent_name
   ON parent.id = parent_name.object_ref_id
-JOIN organization_organizationdivisionid AS parent_country
+LEFT JOIN organization_organizationdivisionid AS parent_country
   ON parent.id = parent_country.object_ref_id
 LEFT JOIN composition_compositionclassification AS comp_classification
   ON comp_object_ref.id = comp_classification.object_ref_id

--- a/sfm_pc/sql/parentage.sql
+++ b/sfm_pc/sql/parentage.sql
@@ -1,7 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS child_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,
@@ -13,7 +13,7 @@ SELECT
   AS start_date_of_organization,
   MAX(open_ended.value) AS open_ended,
   parent.uuid AS parent_id,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS parent_country_iso,
+  substring(MAX(parent_country.value), position(':' IN MAX(parent_country.value)) + 1, 2) AS parent_country_iso,
   MAX(parent_name.value) AS parent_name,
   array_to_string(array_agg(DISTINCT comp_classification.value), ';') AS relationship_classifications,
   MAX(comp_firstciteddate.value) AS relationship_first_cited_date,
@@ -51,6 +51,8 @@ LEFT JOIN organization_organization AS parent
   ON comp_parent.value_id = parent.id
 LEFT JOIN organization_organizationname AS parent_name
   ON parent.id = parent_name.object_ref_id
+JOIN organization_organizationdivisionid AS parent_country
+  ON parent.id = parent_country.object_ref_id
 LEFT JOIN composition_compositionclassification AS comp_classification
   ON comp_object_ref.id = comp_classification.object_ref_id
 LEFT JOIN composition_compositionstartdate AS comp_firstciteddate

--- a/sfm_pc/sql/personnel.sql
+++ b/sfm_pc/sql/personnel.sql
@@ -1,7 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS org_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,
@@ -15,7 +15,7 @@ SELECT
   person.uuid AS person_id,
   MAX(person_name.value) AS person_name,
   array_to_string(array_agg(DISTINCT person_alias.value), ';') AS person_other_names,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS person_country_iso,
+  substring(MAX(person_country.value), position(':' IN MAX(person_country.value)) + 1, 2) AS person_country_iso,
   MAX(person_date_of_birth.value) AS person_date_of_birth,
   MAX(person_date_of_death.value) AS person_date_of_death,
   bool_and(person_deceased.value) AS person_deceased,
@@ -72,6 +72,8 @@ JOIN person_person AS person
   ON member.value_id = person.id
 JOIN person_personname AS person_name
   ON person.id = person_name.object_ref_id
+LEFT JOIN person_persondivisionid as person_country
+  ON person.id = person_country.id
 LEFT JOIN person_personalias AS person_alias
   ON person.id = person_alias.object_ref_id
 LEFT JOIN person_persondateofbirth AS person_date_of_birth

--- a/sfm_pc/sql/personnel.sql
+++ b/sfm_pc/sql/personnel.sql
@@ -1,8 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  MAX(division_id.value) AS division_id,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS country_iso,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,
@@ -16,6 +15,7 @@ SELECT
   person.uuid AS person_id,
   MAX(person_name.value) AS person_name,
   array_to_string(array_agg(DISTINCT person_alias.value), ';') AS person_other_names,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS person_country_iso,
   MAX(person_date_of_birth.value) AS person_date_of_birth,
   MAX(person_date_of_death.value) AS person_date_of_death,
   bool_and(person_deceased.value) AS person_deceased,

--- a/sfm_pc/sql/personnel.sql
+++ b/sfm_pc/sql/personnel.sql
@@ -1,7 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS org_country_iso,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS organization_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,

--- a/sfm_pc/sql/sites.sql
+++ b/sfm_pc/sql/sites.sql
@@ -1,7 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS org_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,

--- a/sfm_pc/sql/sites.sql
+++ b/sfm_pc/sql/sites.sql
@@ -1,7 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS org_country_iso,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS organization_country_iso,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,

--- a/sfm_pc/sql/sites.sql
+++ b/sfm_pc/sql/sites.sql
@@ -1,8 +1,7 @@
 SELECT
   object_ref.uuid AS uuid,
   MAX(name.value) AS name,
-  MAX(division_id.value) AS division_id,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS country_iso,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS division_id,
   array_to_string(array_agg(DISTINCT classifications.value), ';') AS classifications,
   array_to_string(array_agg(DISTINCT aliases.value), ';') AS other_names,
   MAX(firstciteddate.value) AS first_cited_date,
@@ -15,6 +14,7 @@ SELECT
   MAX(open_ended.value) AS open_ended,
   location.id AS site_osm_id,
   MAX(location.name) AS site_name,
+  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS site_country_iso,
   MAX(location.feature_type) AS site_osm_feature_type,
   MAX(location.adminlevel) AS site_admin_level,
   MAX(adminlevel1.id) AS admin_level_1_id,

--- a/sfm_pc/sql/sites.sql
+++ b/sfm_pc/sql/sites.sql
@@ -14,7 +14,7 @@ SELECT
   MAX(open_ended.value) AS open_ended,
   location.id AS site_osm_id,
   MAX(location.name) AS site_name,
-  substring(MAX(division_id.value), position(':' IN MAX(division_id.value)) + 1, 2) AS site_country_iso,
+  substring(MAX(location.division_id), position(':' IN MAX(location.division_id)) + 1, 2) AS site_country_iso,
   MAX(location.feature_type) AS site_osm_feature_type,
   MAX(location.adminlevel) AS site_admin_level,
   MAX(adminlevel1.id) AS admin_level_1_id,


### PR DESCRIPTION
## Overview

This PR makes the changes to the download functionality as requested in #602. It adds in the country code for each organization *and* the entity represented, as they can differ.

## Testing Instructions

- For each type of download excluding Basics, download a data set
- Confirm the header has `org_country_iso` and `{entity}_country_iso`
- For the first line, confirm that the data in the download matches the entries on WWIC when you search for them manually

*(I'm open to better ways of testing this)*
