### PR TITLE
Clean up unused Locations and open up Site feature types

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Import entity data from Google Drive:
     # blackbox_cat configs/credentials.json.gpg > sfm_pc/management/commands/credentials.json
     make import_google_docs
 
+Clean up unused Locations:
+
+    python manage.py clean_locations
+
 Make materialized views for the app based on the imported data:
 
     python manage.py make_flattened_views --recreate

--- a/sfm_pc/management/commands/clean_locations.py
+++ b/sfm_pc/management/commands/clean_locations.py
@@ -1,0 +1,22 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+
+from location.models import Location
+
+
+class Command(BaseCommand):
+    help = 'Clear extraneous OSM data from the database.'
+
+    def handle(self, *args, **kwargs):
+        if Location.objects.count() == 0:
+            raise CommandError('No Locations found -- did you run link_locations first?')
+
+        num_deleted, _ = Location.objects.filter(
+            Q(associationarea__isnull=True) &
+            Q(emplacementsite__isnull=True) &
+            Q(violationlocation__isnull=True)
+        ).delete()
+
+        self.stdout.write(
+            self.style.SUCCESS('Deleted {} extraneous locations'.format(num_deleted))
+        )

--- a/templates/organization/create-emplacement.html
+++ b/templates/organization/create-emplacement.html
@@ -165,7 +165,7 @@
 {% block location_select2 %}
 $('.location').select2({
     ajax: {
-        url: "{% url 'location-autocomplete' %}?feature_type=node",
+        url: "{% url 'location-autocomplete' %}",
         data: function(params){
             var query = {
                 q: params.term

--- a/templates/organization/edit-locations.html
+++ b/templates/organization/edit-locations.html
@@ -91,11 +91,7 @@
             {% block location_select2 %}
             $('.location').select2({
                 ajax: {
-                    {% if current_emplacement %}
-                        url: "{% url 'location-autocomplete' %}?feature_type=node",
-                    {% else %}
-                        url: "{% url 'location-autocomplete' %}?feature_type=relation",
-                    {% endif %}
+                    url: "{% url 'location-autocomplete' %}{% if current_association %}?feature_type=relation{% endif %}",
                     data: function(params){
                         var query = {
                             q: params.term


### PR DESCRIPTION
## Overview

This PR makes two changes to Locations:

1. Implements a new management command, `clean_locations`, that removes unused Locations from the database
2. Opens up the Site create/edit UI to allow Sites to use Locations of any feature type (including both points and polygons)

Connects #610 

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Run `python manage.py clean_locations` and wait 5-10 minutes for it to complete
* Open up a shell with `python manage.py shell` and run `Location.objects.count()` to confirm you only have ~4,000 Locations remaining in your DB
* Run a development server, navigate to an edit view for an Organization, and select `Add site`
* Search for `New Cairo City`, a polygon shape, and confirm that you can add it as a site
