### PR TITLE
Update public-facing templates for field harmonization

### DIFF
--- a/area/models.py
+++ b/area/models.py
@@ -8,10 +8,10 @@ from complex_fields.model_decorators import (versioned, translated, sourced,
 from complex_fields.models import ComplexField, ComplexFieldContainer
 from complex_fields.base_models import BaseModel
 
-from sfm_pc.models import GetComplexSpreadsheetFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin
 
 
-class Area(models.Model, BaseModel, GetComplexSpreadsheetFieldNameMixin):
+class Area(models.Model, BaseModel, GetComplexFieldNameMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.name = ComplexFieldContainer(self, AreaName)

--- a/association/models.py
+++ b/association/models.py
@@ -9,10 +9,10 @@ from complex_fields.models import ComplexField, ComplexFieldContainer
 from complex_fields.base_models import BaseModel
 from organization.models import Organization
 from location.models import Location
-from sfm_pc.models import GetComplexSpreadsheetFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin
 
 
-class Association(models.Model, BaseModel, GetComplexSpreadsheetFieldNameMixin):
+class Association(models.Model, BaseModel, GetComplexFieldNameMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.startdate = ComplexFieldContainer(self, AssociationStartDate)

--- a/composition/models.py
+++ b/composition/models.py
@@ -8,10 +8,10 @@ from organization.models import Organization
 from complex_fields.model_decorators import versioned, sourced, sourced_optional
 from complex_fields.models import ComplexField, ComplexFieldContainer
 from complex_fields.base_models import BaseModel
-from sfm_pc.models import GetComplexSpreadsheetFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin
 
 
-class Composition(models.Model, BaseModel, GetComplexSpreadsheetFieldNameMixin):
+class Composition(models.Model, BaseModel, GetComplexFieldNameMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.parent = ComplexFieldContainer(self, CompositionParent)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     container_name: sfm-solr
     volumes:
       - ./solr_configs:/sfm_configs
-      - sfm-cms-solr-data:/opt/solr/server/solr/mycores
+      - sfm-cms-solr-data:/opt/solr/server/solr
     command: sh -c 'solr-create -c sfm -d /sfm_configs'
     ports:
       - '8983:8983'

--- a/emplacement/models.py
+++ b/emplacement/models.py
@@ -13,10 +13,10 @@ from complex_fields.models import (ComplexField, ComplexFieldContainer,
 from complex_fields.base_models import BaseModel
 from organization.models import Organization
 from location.models import Location
-from sfm_pc.models import GetComplexSpreadsheetFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin
 
 
-class Emplacement(models.Model, BaseModel, GetComplexSpreadsheetFieldNameMixin):
+class Emplacement(models.Model, BaseModel, GetComplexFieldNameMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.startdate = ComplexFieldContainer(self, EmplacementStartDate)

--- a/membershiporganization/models.py
+++ b/membershiporganization/models.py
@@ -10,10 +10,10 @@ from complex_fields.model_decorators import versioned, sourced, sourced_optional
 from complex_fields.models import ComplexField, ComplexFieldContainer
 from complex_fields.base_models import BaseModel
 from organization.models import Organization
-from sfm_pc.models import GetComplexSpreadsheetFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin
 
 
-class MembershipOrganization(models.Model, BaseModel, GetComplexSpreadsheetFieldNameMixin):
+class MembershipOrganization(models.Model, BaseModel, GetComplexFieldNameMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.member = ComplexFieldContainer(self, MembershipOrganizationMember)

--- a/membershipperson/models.py
+++ b/membershipperson/models.py
@@ -11,10 +11,10 @@ from complex_fields.base_models import BaseModel
 
 from person.models import Person
 from organization.models import Organization
-from sfm_pc.models import GetComplexSpreadsheetFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin
 
 
-class MembershipPerson(models.Model, BaseModel, GetComplexSpreadsheetFieldNameMixin):
+class MembershipPerson(models.Model, BaseModel, GetComplexFieldNameMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.member = ComplexFieldContainer(self, MembershipPersonMember)

--- a/organization/models.py
+++ b/organization/models.py
@@ -16,7 +16,7 @@ from complex_fields.base_models import BaseModel
 from django_date_extensions.fields import ApproximateDateField
 
 from sfm_pc.utils import VersionsMixin
-from sfm_pc.models import GetComplexSpreadsheetFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin
 
 VERSION_RELATED_FIELDS = [
     'associationorganization_set',
@@ -38,7 +38,7 @@ VERSION_RELATED_FIELDS = [
 
 
 @reversion.register(follow=VERSION_RELATED_FIELDS)
-class Organization(models.Model, BaseModel, VersionsMixin, GetComplexSpreadsheetFieldNameMixin):
+class Organization(models.Model, BaseModel, VersionsMixin, GetComplexFieldNameMixin):
 
     uuid = models.UUIDField(default=uuid.uuid4,
                             editable=False,

--- a/person/models.py
+++ b/person/models.py
@@ -15,7 +15,7 @@ from complex_fields.models import ComplexField, ComplexFieldContainer, \
 from complex_fields.base_models import BaseModel
 
 from sfm_pc.utils import VersionsMixin
-from sfm_pc.models import GetComplexSpreadsheetFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin
 
 
 VERSION_RELATED_FIELDS = [
@@ -31,7 +31,7 @@ VERSION_RELATED_FIELDS = [
 
 
 @reversion.register(follow=VERSION_RELATED_FIELDS)
-class Person(models.Model, BaseModel, VersionsMixin, GetComplexSpreadsheetFieldNameMixin):
+class Person(models.Model, BaseModel, VersionsMixin, GetComplexFieldNameMixin):
 
     uuid = models.UUIDField(default=uuid.uuid4,
                             editable=False,

--- a/personbiography/migrations/0001_initial.py
+++ b/personbiography/migrations/0001_initial.py
@@ -29,7 +29,7 @@ class Migration(migrations.Migration):
             options={
                 'verbose_name_plural': 'person biographies',
             },
-            bases=(models.Model, complex_fields.base_models.BaseModel, sfm_pc.utils.VersionsMixin, sfm_pc.models.GetComplexSpreadsheetFieldNameMixin),
+            bases=(models.Model, complex_fields.base_models.BaseModel, sfm_pc.utils.VersionsMixin, sfm_pc.models.GetComplexFieldNameMixin),
         ),
         migrations.CreateModel(
             name='PersonBiographyDateOfBirth',

--- a/personbiography/models.py
+++ b/personbiography/models.py
@@ -9,11 +9,11 @@ from complex_fields.base_models import BaseModel
 from complex_fields.models import ComplexField, ComplexFieldContainer
 
 from sfm_pc.utils import VersionsMixin
-from sfm_pc.models import GetComplexSpreadsheetFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin
 
 
 @reversion.register()
-class PersonBiography(models.Model, BaseModel, VersionsMixin, GetComplexSpreadsheetFieldNameMixin):
+class PersonBiography(models.Model, BaseModel, VersionsMixin, GetComplexFieldNameMixin):
     """
     Extra biographical metadata for Persons.
     """

--- a/personextra/migrations/0001_initial.py
+++ b/personextra/migrations/0001_initial.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
             ],
-            bases=(models.Model, complex_fields.base_models.BaseModel, sfm_pc.utils.VersionsMixin, sfm_pc.models.GetComplexSpreadsheetFieldNameMixin),
+            bases=(models.Model, complex_fields.base_models.BaseModel, sfm_pc.utils.VersionsMixin, sfm_pc.models.GetComplexFieldNameMixin),
         ),
         migrations.CreateModel(
             name='PersonExtraAccount',

--- a/personextra/models.py
+++ b/personextra/models.py
@@ -8,11 +8,11 @@ from complex_fields.base_models import BaseModel
 from complex_fields.models import ComplexField, ComplexFieldContainer
 
 from sfm_pc.utils import VersionsMixin
-from sfm_pc.models import GetComplexSpreadsheetFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin
 
 
 @reversion.register()
-class PersonExtra(models.Model, BaseModel, VersionsMixin, GetComplexSpreadsheetFieldNameMixin):
+class PersonExtra(models.Model, BaseModel, VersionsMixin, GetComplexFieldNameMixin):
     """
     Extra information for Persons, intended to have a many-to-one relationship.
     """

--- a/search/views.py
+++ b/search/views.py
@@ -409,7 +409,8 @@ def search(request):
         'MembershipPerson': MembershipPerson,
         'Organization': Organization,
         'Emplacement': Emplacement,
-        'Violation': Violation
+        'Violation': Violation,
+        'Source': Source
     }
 
     return render(request, 'search/search.html', context)

--- a/search/views.py
+++ b/search/views.py
@@ -10,7 +10,9 @@ import pysolr
 
 from source.models import Source
 from organization.models import Organization
+from emplacement.models import Emplacement
 from person.models import Person
+from membershipperson.models import MembershipPerson
 from violation.models import Violation
 from sfm_pc.utils import get_osm_by_id, format_facets
 
@@ -402,6 +404,13 @@ def get_search_context(request, all_results=False):
 def search(request):
 
     context = get_search_context(request)
+    context['models'] = {
+        'Person': Person,
+        'MembershipPerson': MembershipPerson,
+        'Organization': Organization,
+        'Emplacement': Emplacement,
+        'Violation': Violation
+    }
 
     return render(request, 'search/search.html', context)
 

--- a/sfm_pc/base_views.py
+++ b/sfm_pc/base_views.py
@@ -21,6 +21,14 @@ from countries_plus.models import Country
 from extra_views import FormSetView
 
 from source.models import AccessPoint
+from association.models import Association
+from emplacement.models import Emplacement
+from person.models import Person
+from organization.models import Organization
+from membershipperson.models import MembershipPerson
+from membershiporganization.models import MembershipOrganization
+from violation.models import Violation
+
 
 class CacheMixin(object):
     cache_timeout = 60 * 60 * 24
@@ -48,6 +56,21 @@ class CreateUpdateMixin(object):
 
 
 class BaseDetailView(DetailView):
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data()
+        # Pass in a dictionary of models so that child views can reference
+        # model metadata.
+        context['models'] = {
+            'Association': Association,
+            'Emplacement': Emplacement,
+            'MembershipOrganization': MembershipOrganization,
+            'Person': Person,
+            'MembershipPerson': MembershipPerson,
+            'Violation': Violation,
+            'Organization': Organization
+        }
+        return context
+
     def get_queryset(self):
 
         queryset = super().get_queryset()

--- a/sfm_pc/models.py
+++ b/sfm_pc/models.py
@@ -1,15 +1,15 @@
 from complex_fields.models import ComplexFieldContainer
 
 
-class GetComplexSpreadsheetFieldNameMixin:
+class GetComplexFieldNameMixin:
     """
-    Mixin to allow models with ComplexFields to retrieve the
-    spreadsheet field names for a given ComplexField.
+    Mixin to allow models with ComplexFields to retrieve the different types of
+    field names for a given ComplexField.
     """
     @classmethod
     def get_field_model(cls, field_name):
         """
-        Return the model corresponding to a field on this model.
+        Return the ComplexField model corresponding to a field on this model.
         """
         # Get the 0th ID instance, to indicate that we don't want a specific instance
         # (for more information on these methods, see the source code in the
@@ -18,6 +18,24 @@ class GetComplexSpreadsheetFieldNameMixin:
             cls.__name__.lower(), '0', field_name
         )
         return container.field_model()
+
+    @classmethod
+    def get_verbose_field_name(cls, field_name):
+        """
+        Get the canonical verbose name for a given field_name. For instance,
+        the verbose name for Person.aliases would be 'Other names'.
+        """
+        field_model = cls.get_field_model(field_name)
+        return field_model.field_name
+
+    @classmethod
+    def get_shortcode(cls, field_name):
+        """
+        Get the shortcode for a given field_name. For instance, the shortcode
+        for Person.aliases would be 'p_on'.
+        """
+        field_model = cls.get_field_model(field_name)
+        return field_model.shortcode
 
     @classmethod
     def get_spreadsheet_field_name(cls, field_name):

--- a/sfm_pc/settings.py
+++ b/sfm_pc/settings.py
@@ -335,4 +335,4 @@ OPEN_ENDED_CHOICES = (
 )
 
 # Format this string with the user's language code
-RESEARCH_HANDBOOK_URL = "https://help.securityforcemonitor.org/v"
+RESEARCH_HANDBOOK_URL = "https://help.securityforcemonitor.org"

--- a/sfm_pc/templatetags/help.py
+++ b/sfm_pc/templatetags/help.py
@@ -13,11 +13,11 @@ def help(href=''):
     To make linking easier, we pull in the base URL from the settings file, so
     all you have to do to make a link is add an inclusion tag like so:
 
-    `{% help 'whowasincommand/personsrec.html' %}`
+    `{% help 'personsrec.html' %}`
 
     Which will link out to:
 
-    `https://help.securityforcemonitor.org/{lang}/whowasincommand/personsrec.html`
+    `https://help.securityforcemonitor.org/{lang}/latest/personsrec.html`
     '''
     context = {}
 

--- a/sfm_pc/templatetags/model_meta.py
+++ b/sfm_pc/templatetags/model_meta.py
@@ -1,0 +1,14 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def verbose_field_name(Model, field):
+    """
+    Return the verbose fieldname for a given 'field' on a Model.
+    """
+    if hasattr(Model, 'get_verbose_field_name'):
+        return Model.get_verbose_field_name(field)
+    else:
+        return Model._meta.get_field(field).verbose_name

--- a/source/models.py
+++ b/source/models.py
@@ -35,6 +35,10 @@ class GetSpreadsheetFieldNameMixin:
     def get_spreadsheet_field_name(cls, field_name):
         return cls._meta.get_field(field_name).spreadsheet_field_name
 
+    @classmethod
+    def get_verbose_field_name(cls, field_name):
+        return cls._meta.get_field(field_name).verbose_name.title()
+
 
 @reversion.register(follow=['accesspoint_set'])
 class Source(models.Model, GetSpreadsheetFieldNameMixin, VersionsMixin):

--- a/templates/location/list.html
+++ b/templates/location/list.html
@@ -65,7 +65,7 @@
         <br />
         <p>
             {% trans "For better results, try adjusting your search filters." %}
-        {% help href='whowasincommand/generalfunctions.html#how-do-i-find-what-im-looking-for' %}
+        {% help href='generalfunctions.html#how-do-i-find-what-i-m-looking-for' %}
         </p>
         <p>{% trans "Think we're missing something?" %} <a href="mailto:technical@securityforcemonitor.org">{% trans "Let us know!" %}</a></p>
     {% endif %}

--- a/templates/organization/edit-composition.html
+++ b/templates/organization/edit-composition.html
@@ -8,7 +8,7 @@
 <h3 id="relationships">
     <i class="fa fa-fw fa-users"></i>
     {% trans "Relationships" %}
-    <small class="pull-right">{% help href='whowasincommand/unitrec.html#anatomy_unit_record_subsidiaries' %}</small>
+    <small class="pull-right">{% help href='unitrec.html#unit-record-unit-subsidiaries' %}</small>
 </h3>
 <hr />
 <table class="table table-condensed">

--- a/templates/organization/edit-membership.html
+++ b/templates/organization/edit-membership.html
@@ -8,7 +8,7 @@
 <h3 id="relationships">
     <i class="fa fa-fw fa-users"></i>
     {% trans "Relationships" %}
-    <small class="pull-right">{% help href='whowasincommand/unitrec.html#anatomy_unit_record_subsidiaries' %}</small>
+    <small class="pull-right">{% help href='unitrec.html#unit-record-unit-subsidiaries' %}</small>
 </h3>
 <hr />
 <table class="table table-condensed">

--- a/templates/organization/partials/personnel-list.html
+++ b/templates/organization/partials/personnel-list.html
@@ -4,7 +4,7 @@
 <h3 id="memberships">
     <i class="fa fa-fw fa-users"></i>
     {% trans "Personnel" %}
-    <small class="pull-right">{% help href='whowasincommand/personsrec.html#person_record_anatomy_memberships' %}</small>
+    <small class="pull-right">{% help href='personsrec.html#person-record-person-memberships' %}</small>
 </h3>
 <hr />
 <table class="table table-condensed">

--- a/templates/organization/view.html
+++ b/templates/organization/view.html
@@ -16,7 +16,7 @@
     <h2 class="page-title cited">
         <i class="fa fa-fw fa-users"></i>
         {{ organization.name.get_value }}
-        <small>{% help href='whowasincommand/unitrec.html#anatomy_unit_record_title' %}</small>
+        <small>{% help href='unitrec.html#unit-record-title-area' %}</small>
         {% cite organization.name.get_value %}
         <small class="pull-right">
             <a class="btn btn-default" type="button" role="button" href="{{ download_url }}"><i class="fa fa-fw fa-download"></i>{% trans "Download as CSV" %}</a>
@@ -55,7 +55,7 @@
 {% endblock %}
 
 {% block contents_help %}
-    <small>{% help href='whowasincommand/unitrec.html#anatomy_unit_record_sidebar' %}</small>
+    <small>{% help href='unitrec.html#unit-record-content-sidebar' %}</small>
 {% endblock %}
 
 {% block sidebar %}
@@ -95,7 +95,7 @@
         <div class="col-sm-12">
             <h3 id="areas-of-operation"><i class="fa fa-fw fa-globe"></i>
                 {% trans "Areas of operation" %}
-                <small class="pull-right">{% help href='whowasincommand/unitrec.html#anatomy_unit_record_area_of_operation' %}</small>
+                <small class="pull-right">{% help href='unitrec.html#unit-record-areas-of-operation' %}</small>
             </h3>
             <hr />
             <div id="osm_area_map" style="height:300px;"></div>
@@ -149,7 +149,7 @@
             <h3 id="sites">
                 <i class="fa fa-fw fa-map-marker"></i>
                 {% trans "Sites" %}
-                <small class="pull-right">{% help href='whowasincommand/unitrec.html#anatomy_unit_record_sites' %}</small>
+                <small class="pull-right">{% help href='unitrec.html#unit-record-sites' %}</small>
             </h3>
             <hr />
             <div id="osm_site_map" style="height:300px;"></div>
@@ -205,7 +205,7 @@
                 {% trans "Memberships" %}
             </h3>
             <small>{% trans "Multi-unit organizations that this unit is part of" %}</small>
-            <small class="pull-right">{% help href='whowasincommand/unitrec.html#anatomy_unit_record_memberships' %}</small>
+            <small class="pull-right">{% help href='unitrec.html#unit-record-memberships' %}</small>
             <hr />
             <table class="table table-condensed">
                 <thead>
@@ -268,7 +268,7 @@
                 {% trans "Member units" %}
             </h3>
             <small>{% trans "All units that comprise this unit." %}</small>
-            <small class="pull-right">{% help href='whowasincommand/unitrec.html#anatomy_unit_record_member_units' %}</small>
+            <small class="pull-right">{% help href='unitrec.html#unit-record-member-units' %}</small>
             <hr />
             <table class="table table-condensed">
                 <thead>
@@ -333,7 +333,7 @@
                         {% trans "Parent units" %}
                     </h3>
                     <small>{% trans "All units that have held a command position over this unit." %}</small>
-                    <small class="pull-right">{% help href='whowasincommand/unitrec.html#anatomy_unit_record_parents' %}</small>
+                    <small class="pull-right">{% help href='unitrec.html#unit-record-parent-units' %}</small>
                     <hr />
                     <small><em>{% trans "Swipe to zoom, click and drag to pan" %}</em></small>
                     <div id="org-chart-container" class="command-charts-carousel"></div>
@@ -350,7 +350,7 @@
             <h3 id="subsidiaries">
                 <i class="fa fa-fw fa-sitemap"></i>
                 {% trans "Subsidiaries" %}
-                <small class="pull-right">{% help href='whowasincommand/unitrec.html#anatomy_unit_record_subsidiaries' %}</small>
+                <small class="pull-right">{% help href='unitrec.html#unit-record-unit-subsidiaries' %}</small>
             </h3>
             <hr />
             <table class="table table-condensed">
@@ -416,7 +416,7 @@
                 {% trans "Personnel" %}
             </h3>
             <small>{% trans "Table showing personnel linked to this unit in command, administrative and other roles" %}</small>
-            <small class="pull-right">{% help href='whowasincommand/unitrec.html#anatomy_unit_record_personnel' %}</small>
+            <small class="pull-right">{% help href='unitrec.html#unit-record-unit-personnel' %}</small>
             <hr />
             <table class="table table-condensed">
                 <thead>
@@ -472,7 +472,7 @@
             <h3 id="incidents">
                 <i class="fa fa-fw fa-exclamation-triangle"></i>
                 {% trans "Incidents" %}
-                <small class="pull-right">{% help href='whowasincommand/unitrec.html#anatomy_unit_record_incidents' %}</small>
+                <small class="pull-right">{% help href='unitrec.html#unit-record-unit-incidents' %}</small>
             </h3>
             <hr />
             {% for event in events %}

--- a/templates/organization/view.html
+++ b/templates/organization/view.html
@@ -4,6 +4,7 @@
 {% load countries %}
 {% load citations %}
 {% load help %}
+{% load model_meta %}
 
 {% if sites %}
     {% block extra_head %}
@@ -102,9 +103,9 @@
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>{% trans "Area" %}</th>
-                        <th>{% trans "First cited" %}</th>
-                        <th>{% trans "Last cited" %}</th>
+                        <th>{{ models.Association|verbose_field_name:"area" }}</th>
+                        <th>{{ models.Association|verbose_field_name:"startdate" }}</th>
+                        <th>{{ models.Association|verbose_field_name:"enddate" }}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -156,9 +157,9 @@
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>{% trans "Site" %}</th>
-                        <th>{% trans "First cited" %}</th>
-                        <th>{% trans "Last cited" %}</th>
+                        <th>{{ models.Emplacement|verbose_field_name:"site" }}</th>
+                        <th>{{ models.Emplacement|verbose_field_name:"startdate" }}</th>
+                        <th>{{ models.Emplacement|verbose_field_name:"enddate" }}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -209,11 +210,11 @@
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>{% trans "Name" %}</th>
-                        <th>{% trans "Aliases" %}</th>
-                        <th>{% trans "Classifications" %}</th>
-                        <th>{% trans "First cited" %}</th>
-                        <th>{% trans "Last cited" %}</th>
+                        <th>{{ view.model|verbose_field_name:"name" }}</th>
+                        <th>{{ view.model|verbose_field_name:"aliases" }}</th>
+                        <th>{{ view.model|verbose_field_name:"classification" }}</th>
+                        <th>{{ view.model|verbose_field_name:"firstciteddate" }}</th>
+                        <th>{{ view.model|verbose_field_name:"lastciteddate" }}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -272,11 +273,11 @@
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>{% trans "Name" %}</th>
-                        <th>{% trans "Aliases" %}</th>
-                        <th>{% trans "Classifications" %}</th>
-                        <th>{% trans "First cited" %}</th>
-                        <th>{% trans "Last cited" %}</th>
+                        <th>{{ view.model|verbose_field_name:"name" }}</th>
+                        <th>{{ view.model|verbose_field_name:"aliases" }}</th>
+                        <th>{{ view.model|verbose_field_name:"classification" }}</th>
+                        <th>{{ view.model|verbose_field_name:"firstciteddate" }}</th>
+                        <th>{{ view.model|verbose_field_name:"lastciteddate" }}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -355,11 +356,11 @@
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>{% trans "Name" %}</th>
-                        <th>{% trans "Aliases" %}</th>
-                        <th>{% trans "Classifications" %}</th>
-                        <th>{% trans "First cited" %}</th>
-                        <th>{% trans "Last cited" %}</th>
+                        <th>{{ view.model|verbose_field_name:"name" }}</th>
+                        <th>{{ view.model|verbose_field_name:"aliases" }}</th>
+                        <th>{{ view.model|verbose_field_name:"classification" }}</th>
+                        <th>{{ view.model|verbose_field_name:"firstciteddate" }}</th>
+                        <th>{{ view.model|verbose_field_name:"lastciteddate" }}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -420,12 +421,12 @@
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>{% trans "Name" %}</th>
-                        <th>{% trans "Rank" %}</th>
-                        <th>{% trans "Role" %}</th>
-                        <th>{% trans "Title" %}</th>
-                        <th>{% trans "First cited" %}</th>
-                        <th>{% trans "Last cited" %}</th>
+                        <th>{{ models.Person|verbose_field_name:"name" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"rank" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"role" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"title" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"firstciteddate" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"lastciteddate" }}</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/templates/partials/datetype.html
+++ b/templates/partials/datetype.html
@@ -9,7 +9,7 @@
        data-html="true"
        data-placement="top"
        data-content=""
-       data-original-title="<div class='tooltip-title'><p class='text-left'>{{ title }}<a type='button' role='button' class='close pull-right' aria-hidden='true' aria-label='Close'>&times;</a><span class='pull-right'>{% help href='whowasincommand/generalfunctions.html#why-do-some-dates-have-a-dotted-line-beneath-them-and-some-dont' %}</span></div>{{ content }}"
+       data-original-title="<div class='tooltip-title'><p class='text-left'>{{ title }}<a type='button' role='button' class='close pull-right' aria-hidden='true' aria-label='Close'>&times;</a><span class='pull-right'>{% help href='generalfunctions.html#why-do-some-dates-have-a-dotted-line-beneath-them-and-some-don-t' %}</span></div>{{ content }}"
        data-trigger="focus"
        tabindex="0"
        aria-label="{% trans 'Real date label' %}">

--- a/templates/partials/help_widget.html
+++ b/templates/partials/help_widget.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% get_current_language as LANGUAGE_CODE %}
-<a href='{{ base_url }}/{{ LANGUAGE_CODE }}/{{ href }}' class='help-widget' target='_blank'
+<a href='{{ base_url }}/{{ LANGUAGE_CODE }}/latest/{{ href }}' class='help-widget' target='_blank'
 aria-label='{% trans "Link to our research guide help text for this information" %}'>
     <i class='fa fa-fw fa-question-circle'></i>
 </a>

--- a/templates/partials/organization_list_table.html
+++ b/templates/partials/organization_list_table.html
@@ -2,6 +2,7 @@
 {% load citations %}
 {% load countries %}
 {% load i18n %}
+{% load model_meta %}
 
 <div class="responsive-table">
     <table class="table table-striped table-condensed search-results-table">
@@ -11,7 +12,7 @@
                     <th></th>
                 {% endif %}
                 <th>
-                    {% trans "Name" %}
+                    {{ models.Organization|verbose_field_name:"name" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Organization_sort' sort_asc='organization_name_s_asc' sort_desc='organization_name_s_desc' selected_sort=sorts.Organization %}
                             {% include 'partials/sortable-list.html' %}
@@ -27,7 +28,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Classification" %}
+                    {{ models.Organization|verbose_field_name:"classification" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Organization_sort' sort_asc='organization_classification_count_i_asc' sort_desc='organization_classification_count_i_desc' selected_sort=sorts.Organization %}
                             {% include 'partials/sortable-list.html' %}
@@ -43,7 +44,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Country" %}
+                    {{ models.Organization|verbose_field_name:"division_id" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Organization_sort' sort_asc='organization_country_count_i_asc' sort_desc='organization_country_count_i_desc' selected_sort=sorts.Organization %}
                             {% include 'partials/sortable-list.html' %}
@@ -51,7 +52,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "First cited" %}
+                    {{ models.Organization|verbose_field_name:"firstciteddate" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Organization_sort' sort_asc='start_date_dt_asc' sort_desc='start_date_dt_desc' selected_sort=sorts.Organization %}
                             {% include 'partials/sortable-list.html' %}
@@ -59,7 +60,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Last cited" %}
+                    {{ models.Organization|verbose_field_name:"lastciteddate" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Organization_sort' sort_asc='end_date_dt_asc' sort_desc='end_date_dt_desc' selected_sort=sorts.Organization %}
                             {% include 'partials/sortable-list.html' %}

--- a/templates/partials/person_list_table.html
+++ b/templates/partials/person_list_table.html
@@ -1,6 +1,7 @@
 {% load tablesort %}
 {% load citations %}
 {% load i18n %}
+{% load model_meta %}
 
 <div class="responsive-table">
     <table class="table table-striped table-condensed search-results-table">
@@ -13,7 +14,7 @@
                     <th>{% trans "Select canonical record" %}</th>
                 {% endif %}
                 <th>
-                    {% trans "Name" %}
+                    {{ models.Person|verbose_field_name:"name" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Person_sort' sort_asc='person_name_s_asc' sort_desc='person_name_s_desc' selected_sort=sorts.Person %}
                             {% include 'partials/sortable-list.html' %}
@@ -21,7 +22,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Aliases" %}
+                    {{ models.Person|verbose_field_name:"aliases" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Person_sort' sort_asc='person_alias_count_i_asc' sort_desc='person_alias_count_i_desc' selected_sort=sorts.Person %}
                             {% include 'partials/sortable-list.html' %}
@@ -29,7 +30,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Most recent rank" %}
+                    {% trans "Most Recent Rank" %}
                     {% if sortable == 'True' %}
                         {% with sort_param='Person_sort' sort_asc='person_most_recent_rank_s_asc' sort_desc='person_most_recent_rank_s_desc' selected_sort=sorts.Person %}
                             {% include 'partials/sortable-list.html' %}
@@ -37,7 +38,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Most recent unit" %}
+                    {% trans "Most Recent Unit" %}
                     {% if sortable == 'True' %}
                         {% with sort_param='Person_sort' sort_asc='person_most_recent_unit_s_asc' sort_desc='person_most_recent_unit_s_desc' selected_sort=sorts.Person %}
                             {% include 'partials/sortable-list.html' %}
@@ -45,7 +46,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "First cited" %}
+                    {{ models.MembershipPerson|verbose_field_name:"firstciteddate" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Person_sort' sort_asc='start_date_dt_asc' sort_desc='start_date_dt_desc' selected_sort=sorts.Person %}
                             {% include 'partials/sortable-list.html' %}
@@ -53,7 +54,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Last cited" %}
+                    {{ models.MembershipPerson|verbose_field_name:"lastciteddate" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Person_sort' sort_asc='end_date_dt_asc' sort_desc='end_date_dt_desc' selected_sort=sorts.Person %}
                             {% include 'partials/sortable-list.html' %}

--- a/templates/partials/source_and_confidence.html
+++ b/templates/partials/source_and_confidence.html
@@ -16,7 +16,7 @@
                data-placement="top"
                data-content="Loading ..."
                title="<strong>{% trans 'Sources for this datapoint' %}<a type='button' role='button' class='close pull-right' data-dismiss='popover' aria-hidden='true' aria-label='Close'>&times;</a><p class='pull-right'>{% help href='generalfunctions.html#how-do-i-see-the-sources-used-for-a-specific-datapoint' %}</p><br/>{{ confidence_string }}</strong>"
-               data-trigger="focus"
+               data-trigger="click"
                tabindex="1"
                aria-label="{% trans 'Sources and confidence for this information' %}">
                 <span class="source-footnote-counter"></span>

--- a/templates/partials/source_and_confidence.html
+++ b/templates/partials/source_and_confidence.html
@@ -15,7 +15,7 @@
                data-html="true"
                data-placement="top"
                data-content="Loading ..."
-               title="<strong>{% trans 'Sources for this datapoint' %}<a type='button' role='button' class='close pull-right' data-dismiss='popover' aria-hidden='true' aria-label='Close'>&times;</a><p class='pull-right'>{% help href='whowasincommand/generalfunctions.html#how-do-i-see-the-sources-used-for-a-specific-datapoint' %}</p><br/>{{ confidence_string }}</strong>"
+               title="<strong>{% trans 'Sources for this datapoint' %}<a type='button' role='button' class='close pull-right' data-dismiss='popover' aria-hidden='true' aria-label='Close'>&times;</a><p class='pull-right'>{% help href='generalfunctions.html#how-do-i-see-the-sources-used-for-a-specific-datapoint' %}</p><br/>{{ confidence_string }}</strong>"
                data-trigger="focus"
                tabindex="1"
                aria-label="{% trans 'Sources and confidence for this information' %}">

--- a/templates/partials/source_list_table.html
+++ b/templates/partials/source_list_table.html
@@ -2,13 +2,14 @@
 {% load countries %}
 {% load facets %}
 {% load i18n %}
+{% load model_meta %}
 
 <div class="responsive-table">
     <table class="table table-striped table-condensed search-results-table">
         <thead>
             <tr>
                 <th>
-                    {% trans "Title" %}
+                    {{ models.Source|verbose_field_name:"title" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Source_sort' sort_asc='source_title_t_asc' sort_desc='source_title_t_desc' selected_sort=sorts.Source %}
                             {% include 'partials/sortable-list.html' %}
@@ -16,7 +17,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Publication Date" %}
+                    {{ models.Source|verbose_field_name:"published_date" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Source_sort' sort_asc='start_date_dt_asc' sort_desc='start_date_dt_desc' selected_sort=sorts.Source %}
                             {% include 'partials/sortable-list.html' %}
@@ -24,7 +25,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Publication" %}
+                    {{ models.Source|verbose_field_name:"publication" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Source_sort' sort_asc='publication_s_asc' sort_desc='publication_s_desc' selected_sort=sorts.Source %}
                             {% include 'partials/sortable-list.html' %}
@@ -32,7 +33,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Publication Country" %}
+                    {{ models.Source|verbose_field_name:"publication_country" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Source_sort' sort_asc='country_s_asc' sort_desc='country_s_desc' selected_sort=sorts.Source %}
                             {% include 'partials/sortable-list.html' %}

--- a/templates/partials/violation_list_table.html
+++ b/templates/partials/violation_list_table.html
@@ -2,13 +2,14 @@
 {% load countries %}
 {% load facets %}
 {% load i18n %}
+{% load model_meta %}
 
 <div class="responsive-table">
     <table class="table table-striped table-condensed search-results-table">
         <thead>
             <tr>
                 <th>
-                    {% trans "Start Date" %}
+                    {{ models.Violation|verbose_field_name:"startdate" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Violation_sort' sort_asc='start_date_dt_asc' sort_desc='start_date_dt_desc' selected_sort=sorts.Violation %}
                             {% include 'partials/sortable-list.html' %}
@@ -16,7 +17,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "End Date" %}
+                    {{ models.Violation|verbose_field_name:"enddate" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Violation_sort' sort_asc='end_date_dt_asc' sort_desc='end_date_dt_desc' selected_sort=sorts.Violation %}
                             {% include 'partials/sortable-list.html' %}
@@ -24,7 +25,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Description" %}
+                    {{ models.Violation|verbose_field_name:"description" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Violation_sort' sort_asc='violation_description_t_asc' sort_desc='violation_description_t_desc' selected_sort=sorts.Violation %}
                             {% include 'partials/sortable-list.html' %}
@@ -32,7 +33,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Violation types" %}
+                    {{ models.Violation|verbose_field_name:"types" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Violation_sort' sort_asc='violation_type_count_i_asc' sort_desc='violation_type_count_i_desc' selected_sort=sorts.Violation %}
                             {% include 'partials/sortable-list.html' %}
@@ -40,7 +41,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Location" %}
+                    {{ models.Violation|verbose_field_name:"location" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Violation_sort' sort_asc='violation_location_name_s_asc' sort_desc='violation_location_name_s_desc' selected_sort=sorts.Violation %}
                             {% include 'partials/sortable-list.html' %}
@@ -48,7 +49,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Perpetrators" %}
+                    {{ models.Violation|verbose_field_name:"perpetratororganization" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Violation_sort' sort_asc='perpetrator_organization_count_i_asc' sort_desc='perpetrator_organization_count_i_desc' selected_sort=sorts.Violation %}
                             {% include 'partials/sortable-list.html' %}
@@ -56,7 +57,7 @@
                     {% endif %}
                 </th>
                 <th>
-                    {% trans "Perpetrator classification" %}
+                    {{ models.Violation|verbose_field_name:"perpetratorclassification" }}
                     {% if sortable == 'True' %}
                         {% with sort_param='Violation_sort' sort_asc='perpetrator_classification_count_i_asc' sort_desc='perpetrator_classification_count_i_desc' selected_sort=sorts.Violation %}
                             {% include 'partials/sortable-list.html' %}

--- a/templates/person/partials/person-posting-list.html
+++ b/templates/person/partials/person-posting-list.html
@@ -4,7 +4,7 @@
 <h3 id="memberships">
     <i class="fa fa-fw fa-users"></i>
     {% trans "Postings" %}
-    <small class="pull-right">{% help href='whowasincommand/personsrec.html#person_record_anatomy_memberships' %}</small>
+    <small class="pull-right">{% help href='personsrec.html#person-record-person-memberships' %}</small>
 </h3>
 <hr />
 <table class="table table-condensed">

--- a/templates/person/view.html
+++ b/templates/person/view.html
@@ -10,7 +10,7 @@
     <h2 class="page-title cited">
         <i class="fa fa-fw fa-user"></i>
         {{ person.name.get_value }}
-        <small>{% help href='whowasincommand/personsrec.html#person_record_anatomy_titlearea' %}</small>
+        <small>{% help href='personsrec.html#person-record-title-area' %}</small>
         {% cite person.name.get_value %}
         <small class="pull-right">
             <a class="btn btn-default" type="button" role="button" href="{{ download_url }}"><i class="fa fa-fw fa-download"></i>{% trans "Download as CSV" %}</a>
@@ -41,7 +41,7 @@
 {% endblock %}
 
 {% block contents_help %}
-    <small>{% help href='whowasincommand/personsrec.html#person_record_anatomy_contentsidebar' %}</small>
+    <small>{% help href='personsrec.html#person-record-content-sidebar' %}</small>
 {% endblock %}
 
 {% block sidebar %}
@@ -70,7 +70,7 @@
             <h3 id="last-seen-as">
                 <i class="fa fa-fw fa-clock-o"></i>
                 {% trans "Last seen as" %}
-                <small>{% help href='whowasincommand/personsrec.html#person_record_anatomy_last_seen_as' %}</small>
+                <small>{% help href='personsrec.html#person-record-person-last-seen-as' %}</small>
             </h3>
             {% with membership=memberships|first %}
                 <p class="cited">{{ membership.short_description|safe }}{% cite membership.member.get_value %}</p>
@@ -85,7 +85,7 @@
             <h3 id="memberships">
                 <i class="fa fa-fw fa-users"></i>
                 {% trans "Postings" %}
-                <small class="pull-right">{% help href='whowasincommand/personsrec.html#person_record_anatomy_memberships' %}</small>
+                <small class="pull-right">{% help href='personsrec.html#person-record-person-memberships' %}</small>
             </h3>
             <hr />
             <table class="table table-condensed">
@@ -147,7 +147,7 @@
                 {% trans "Chain of command" %}
             </h3>
             <small>{% trans "Command relationships from a person's posting to the highest-level unit (calculated at the end of the posting)" %}</small>
-            <small class="pull-right">{% help href='whowasincommand/personsrec.html#person_record_anatomy_chain_of_command' %}</small>
+            <small class="pull-right">{% help href='personsrec.html#person-record-chain-of-command' %}</small>
             <hr />
             <small><em>{% trans "Swipe to zoom, click and drag to pan" %}</em></small>
             <div id="org-chart-container" class="command-charts-carousel"></div>
@@ -164,7 +164,7 @@
                 {% trans "Superiors" %}
             </h3>
             <small>{% trans "Commanders of units that were superior to any units commanded by this person" %}</small>
-            <small class="pull-right">{% help href='whowasincommand/personsrec.html#person_record_anatomy_superiors' %}</small>
+            <small class="pull-right">{% help href='personsrec.html#person-record-superiors' %}</small>
             <hr />
             <table class="table table-condensed">
                 <thead>
@@ -226,7 +226,7 @@
                 {% trans "Subordinates" %}
             </h3>
             <small>{% trans "Commanders of units that were subordinate to any units commanded by this person" %}</small>
-            <small class="pull-right">{% help href='whowasincommand/personsrec.html#person_record_anatomy_subordinates' %}</small>
+            <small class="pull-right">{% help href='personsrec.html#person-record-subordinates' %}</small>
             <hr />
             <table class="table table-condensed">
                 <thead>

--- a/templates/person/view.html
+++ b/templates/person/view.html
@@ -4,6 +4,7 @@
 {% load countries %}
 {% load citations %}
 {% load help %}
+{% load model_meta %}
 
 {% block header %}
     <h2 class="page-title cited">
@@ -90,12 +91,12 @@
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>{% trans "Organization" %}</th>
-                        <th>{% trans "Rank" %}</th>
-                        <th>{% trans "Role" %}</th>
-                        <th>{% trans "Title" %}</th>
-                        <th>{% trans "First cited" %}</th>
-                        <th>{% trans "Last cited" %}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"organization" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"rank" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"role" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"title" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"firstciteddate" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"lastciteddate" }}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -168,10 +169,10 @@
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>{% trans "Name" %}</th>
-                        <th>{% trans "Rank" %}</th>
-                        <th>{% trans "Role" %}</th>
-                        <th>{% trans "Unit" %}</th>
+                        <th>{{ view.model|verbose_field_name:"name" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"rank" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"role" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"organization" }}</th>
                         <th>{% trans "Start of overlap" %}</th>
                         <th>{% trans "End of overlap" %}</th>
                         <th>{% trans "Duration of overlap" %}</th>
@@ -230,10 +231,10 @@
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>{% trans "Name" %}</th>
-                        <th>{% trans "Rank" %}</th>
-                        <th>{% trans "Role" %}</th>
-                        <th>{% trans "Unit" %}</th>
+                        <th>{{ view.model|verbose_field_name:"name" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"rank" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"role" }}</th>
+                        <th>{{ models.MembershipPerson|verbose_field_name:"organization" }}</th>
                         <th>{% trans "Start of overlap" %}</th>
                         <th>{% trans "End of overlap" %}</th>
                         <th>{% trans "Duration of overlap" %}</th>
@@ -282,7 +283,7 @@
     {% if events %}
     <div class="row">
         <div class="col-sm-12">
-            <h3>{% trans "Events" %}</h3>
+            <h3>{% trans "Incidents" %}</h3>
             <hr />
             {% for event in events %}
                 <div class="row">

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -290,7 +290,7 @@
         <small><a class="did-you-mean" role="button">{{ term  }}</a></small>
         {% if not forloop.last %}|
         {% else %}
-            <small>{% help href='whowasincommand/generalfunctions.html#why-does-whowasincommand-make-suggestions-to-me' %}</small>
+            <small>{% help href='generalfunctions.html#why-does-whowasincommand-make-suggestions-to-me' %}</small>
         {% endif %}
         {% endfor %}
         </p>
@@ -321,7 +321,7 @@
         <br />
         <p>
             {% trans "For better results, try adjusting your search filters." %}
-        {% help href='whowasincommand/generalfunctions.html#how-do-i-find-what-im-looking-for' %}
+        {% help href='generalfunctions.html#how-do-i-find-what-i-m-looking-for' %}
         </p>
         <p>{% trans "Think we're missing something?" %} <a href="mailto:technical@securityforcemonitor.org">{% trans "Let us know!" %}</a></p>
     {% endif %}

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -268,7 +268,7 @@
                     <div class="panel-body {% if show_filter.Source %}panel-show{% endif %} collapse" id="source-filters">
                         <!-- Publication name -->
                         {% if facets.Source.facet_fields.publication_s_fct.any %}
-                            {% with facet_name='publication_s_fct' facet_label=_('Publication name') selected_list=selected_facets.publication_s_fct item_list=facets.Source.facet_fields.publication_s_fct.counts %}
+                            {% with facet_name='publication_s_fct' facet_label=models.Source|verbose_field_name:"publication" selected_list=selected_facets.publication_s_fct item_list=facets.Source.facet_fields.publication_s_fct.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load humanize %}
 {% load help %}
+{% load model_meta %}
 {% block extra_head %}
   <link rel="stylesheet" href="{% static "css/select2.min.css" %}">
   <link rel="stylesheet" href="{% static "css/bootstrap-datepicker3.min.css" %}">
@@ -107,25 +108,25 @@
                     <div class="panel-body {% if show_filter.Person %}panel-show{% endif %} collapse" id="person-filters">
                         <!-- Role -->
                         {% if facets.Person.facet_fields.person_current_role_s_fct.any %}
-                            {% with facet_name='person_current_role_s_fct' facet_label=_('Role') selected_list=selected_facets.person_current_role_s_fct item_list=facets.Person.facet_fields.person_current_role_s_fct.counts %}
+                            {% with facet_name='person_current_role_s_fct' facet_label=models.MembershipPerson|verbose_field_name:"role" selected_list=selected_facets.person_current_role_s_fct item_list=facets.Person.facet_fields.person_current_role_s_fct.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
                         <!-- Rank -->
                         {% if facets.Person.facet_fields.person_current_rank_s_fct.any %}
-                            {% with facet_name='person_current_rank_s_fct' facet_label=_('Rank') selected_list=selected_facets.person_current_rank_s_fct item_list=facets.Person.facet_fields.person_current_rank_s_fct.counts %}
+                            {% with facet_name='person_current_rank_s_fct' facet_label=models.MembershipPerson|verbose_field_name:"rank" selected_list=selected_facets.person_current_rank_s_fct item_list=facets.Person.facet_fields.person_current_rank_s_fct.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
                         <!-- First cited -->
                         {% if facets.Person.facet_ranges.person_first_cited_dt.any %}
-                            {% with facet_name='person_first_cited_dt' facet_label=_('First cited') selected_list=selected_facets.person_first_cited_dt item_list=facets.Person.facet_ranges.person_first_cited_dt.counts %}
+                            {% with facet_name='person_first_cited_dt' facet_label=models.MembershipPerson|verbose_field_name:"firstciteddate" selected_list=selected_facets.person_first_cited_dt item_list=facets.Person.facet_ranges.person_first_cited_dt.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
                         <!-- Last cited -->
                         {% if facets.Person.facet_ranges.person_last_cited_dt.any %}
-                            {% with facet_name='person_last_cited_dt' facet_label=_('Last cited') selected_list=selected_facets.person_last_cited_dt item_list=facets.Person.facet_ranges.person_last_cited_dt.counts %}
+                            {% with facet_name='person_last_cited_dt' facet_label=models.MembershipPerson|verbose_field_name:"lastciteddate" selected_list=selected_facets.person_last_cited_dt item_list=facets.Person.facet_ranges.person_last_cited_dt.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
@@ -154,7 +155,7 @@
                     <div class="panel-body {% if show_filter.Organization %}panel-show{% endif %} collapse" id="organization-filters">
                         <!-- Classification -->
                         {% if facets.Organization.facet_fields.organization_classification_ss_fct.any %}
-                            {% with facet_name='organization_classification_ss_fct' facet_label=_('Classification') selected_list=selected_facets.organization_classification_ss_fct item_list=facets.Organization.facet_fields.organization_classification_ss_fct.counts %}
+                            {% with facet_name='organization_classification_ss_fct' facet_label=models.Organization|verbose_field_name:"classification" selected_list=selected_facets.organization_classification_ss_fct item_list=facets.Organization.facet_fields.organization_classification_ss_fct.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
@@ -172,19 +173,19 @@
                         {% endif %}
                         <!-- Admin level 1 -->
                         {% if facets.Organization.facet_fields.organization_adminlevel1_ss_fct.any %}
-                            {% with facet_name='organization_adminlevel1_ss_fct' facet_label=_('Place') selected_list=selected_facets.organization_adminlevel1_ss_fct item_list=facets.Organization.facet_fields.organization_adminlevel1_ss_fct.counts %}
+                            {% with facet_name='organization_adminlevel1_ss_fct' facet_label=models.Emplacement|verbose_field_name:"site" selected_list=selected_facets.organization_adminlevel1_ss_fct item_list=facets.Organization.facet_fields.organization_adminlevel1_ss_fct.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
                         <!-- Start date -->
                         {% if facets.Organization.facet_ranges.organization_start_date_dt.any %}
-                            {% with facet_name='organization_start_date_dt' facet_label=_('Start date') selected_list=selected_facets.organization_start_date_dt item_list=facets.Organization.facet_ranges.organization_start_date_dt.counts %}
+                            {% with facet_name='organization_start_date_dt' facet_label=models.Organization|verbose_field_name:"firstciteddate" selected_list=selected_facets.organization_start_date_dt item_list=facets.Organization.facet_ranges.organization_start_date_dt.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
                         <!-- End date -->
                         {% if facets.Organization.facet_ranges.organization_end_date_dt.any %}
-                            {% with facet_name='organization_end_date_dt' facet_label=_('End date') selected_list=selected_facets.organization_end_date_dt item_list=facets.Organization.facet_ranges.organization_end_date_dt.counts %}
+                            {% with facet_name='organization_end_date_dt' facet_label=models.Organization|verbose_field_name:"lastciteddate" selected_list=selected_facets.organization_end_date_dt item_list=facets.Organization.facet_ranges.organization_end_date_dt.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
@@ -213,31 +214,31 @@
                     <div class="panel-body {% if show_filter.Violation %}panel-show{% endif %} collapse" id="violation-filters">
                         <!-- Violation type -->
                         {% if facets.Violation.facet_fields.violation_type_ss_fct.any %}
-                            {% with facet_name='violation_type_ss_fct' facet_label=_('Violation type') selected_list=selected_facets.violation_type_ss_fct item_list=facets.Violation.facet_fields.violation_type_ss_fct.counts %}
+                            {% with facet_name='violation_type_ss_fct' facet_label=models.Violation|verbose_field_name:"types" selected_list=selected_facets.violation_type_ss_fct item_list=facets.Violation.facet_fields.violation_type_ss_fct.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
                         <!-- Perpetrator classification -->
                         {% if facets.Violation.facet_fields.perpetrator_classification_ss_fct.any %}
-                            {% with facet_name='perpetrator_classification_ss_fct' facet_label=_('Perpetrator type') selected_list=selected_facets.perpetrator_classification_ss_fct item_list=facets.Violation.facet_fields.perpetrator_classification_ss_fct.counts %}
+                            {% with facet_name='perpetrator_classification_ss_fct' facet_label=models.Violation|verbose_field_name:"perpetratorclassification" selected_list=selected_facets.perpetrator_classification_ss_fct item_list=facets.Violation.facet_fields.perpetrator_classification_ss_fct.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
                         <!-- Location description -->
                         {% if facets.Violation.facet_fields.violation_location_description_s_fct.any %}
-                            {% with facet_name='violation_location_description_s_fct' facet_label=_('Location description') selected_list=selected_facets.violation_location_description_s_fct item_list=facets.Violation.facet_fields.violation_location_description_s_fct.counts %}
+                            {% with facet_name='violation_location_description_s_fct' facet_label=models.Violation|verbose_field_name:"location" selected_list=selected_facets.violation_location_description_s_fct item_list=facets.Violation.facet_fields.violation_location_description_s_fct.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
                         <!-- Start date -->
                         {% if facets.Violation.facet_ranges.violation_start_date_dt.any %}
-                            {% with facet_name='violation_start_date_dt' facet_label=_('Start date') selected_list=selected_facets.violation_start_date_dt item_list=facets.Violation.facet_ranges.violation_start_date_dt.counts %}
+                            {% with facet_name='violation_start_date_dt' facet_label=models.Violation|verbose_field_name:"startdate" selected_list=selected_facets.violation_start_date_dt item_list=facets.Violation.facet_ranges.violation_start_date_dt.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}
                         <!-- End date -->
                         {% if facets.Violation.facet_ranges.violation_end_date_dt.any %}
-                            {% with facet_name='violation_end_date_dt' facet_label=_('End date') selected_list=selected_facets.violation_end_date_dt item_list=facets.Violation.facet_ranges.violation_end_date_dt.counts %}
+                            {% with facet_name='violation_end_date_dt' facet_label=models.Violation|verbose_field_name:"enddate" selected_list=selected_facets.violation_end_date_dt item_list=facets.Violation.facet_ranges.violation_end_date_dt.counts %}
                                 {% include 'partials/search_filter.html' %}
                             {% endwith %}
                         {% endif %}

--- a/templates/source/view.html
+++ b/templates/source/view.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
+{% load model_meta %}
 {% block content %}
 <div class="row">
     <div class="col-sm-12">
@@ -27,8 +28,8 @@
             <div class="row">
                 <div class="col-sm-12">
                     <p>
-                        <strong>{% trans "Publisher:" %} </strong>{{ source.publication }} ({{ source.publication_country }})<br />
-                        <strong>{% trans "Publication date:" %} </strong>{{ source.published_on }}<br />
+                        <strong>{{ view.model|verbose_field_name:"publication" }}: </strong>{{ source.publication }} ({{ source.publication_country }})<br />
+                        <strong>{{ view.model|verbose_field_name:"published_date" }}: </strong>{{ source.get_published_date }}<br />
                         <strong>{% trans "Last edited by:" %} </strong>{{ source.user }}
                     </p>
                 </div>

--- a/templates/violation/view.html
+++ b/templates/violation/view.html
@@ -4,6 +4,7 @@
 {% load countries %}
 {% load citations %}
 {% load help %}
+{% load model_meta %}
 
 {% if location %}
     {% block extra_head %}
@@ -85,7 +86,7 @@
     {% if location %}<li><a href="#location"><i class="fa fa-fw fa-map-marker"></i> {% trans "Location" %} </a></li>{% endif %}
     {% if violation.description %}<li><a href="#description"><i class="fa fa-fw fa-file-text-o"></i> {% trans "Description" %} </a></li>{% endif %}
     {% if perpetrators %}<li><a href="#perpetrators"><i class="fa fa-fw fa-user"></i> {% trans "Perpetrators" %}</a></li>{% endif %}
-    {% if perpetrator_organizations %}<li><a href="#perpetrator-organizations"><i class="fa fa-fw fa-users"></i> {% trans "Perpetrator organizations" %}</a></li>{% endif %}
+    {% if perpetrator_organizations %}<li><a href="#perpetrator-organizations"><i class="fa fa-fw fa-users"></i> {% trans "Perpetrator units" %}</a></li>{% endif %}
     {% if sources %}<li><a href="#sources"><i class="fa fa-fw fa-files-o"></i> {% trans "Sources" %}</a></li>{% endif %}
 
 {% endblock %}
@@ -97,7 +98,7 @@
     {% if location %}<li><a href="#location"><i class="fa fa-fw fa-map-marker"></i> {% trans "Location" %} </a></li>{% endif %}
     {% if violation.description %}<li><a href="#description"><i class="fa fa-fw fa-file-text-o"></i> {% trans "Description" %} </a></li>{% endif %}
     {% if perpetrators %}<li><a href="#perpetrators"><i class="fa fa-fw fa-user"></i> {% trans "Perpetrators" %}</a></li>{% endif %}
-    {% if perpetrator_organizations %}<li><a href="#perpetrator-organizations"><i class="fa fa-fw fa-users"></i> {% trans "Perpetrator organizations" %}</a></li>{% endif %}
+    {% if perpetrator_organizations %}<li><a href="#perpetrator-organizations"><i class="fa fa-fw fa-users"></i> {% trans "Perpetrator units" %}</a></li>{% endif %}
     {% if sources %}<li><a href="#sources"><i class="fa fa-fw fa-files-o"></i> {% trans "Sources" %}</a></li>{% endif %}
 
 {% endblock %}
@@ -153,8 +154,8 @@
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>{% trans "Name" %}</th>
-                        <th>{% trans "Aliases" %}</th>
+                        <th>{{ models.Person|verbose_field_name:"name" }}</th>
+                        <th>{{ models.Person|verbose_field_name:"aliases" }}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -188,7 +189,7 @@
         <div class="col-sm-12">
             <h3 id="perpetrator-organizations">
                 <i class="fa fa-fw fa-users"></i>
-                {% trans "Perpetrator organizations" %}
+                {% trans "Perpetrator units" %}
                 <small class="pull-right">
                     {% help href='whowasincommand/eventrec.html#incident_record_anatomy_perpetrator_organizations' %}
                 </small>
@@ -196,9 +197,9 @@
             <table class="table table-condensed">
                 <thead>
                     <tr>
-                        <th>{% trans "Name" %}</th>
-                        <th>{% trans "Aliases" %}</th>
-                        <th>{% trans "Classification" %}</th>
+                        <th>{{ models.Organization|verbose_field_name:"name" }}</th>
+                        <th>{{ models.Organization|verbose_field_name:"aliases" }}</th>
+                        <th>{{ models.Organization|verbose_field_name:"classification" }}</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/templates/violation/view.html
+++ b/templates/violation/view.html
@@ -17,7 +17,7 @@
         {% with violation=violation %}
             {% include 'partials/violation_title.html' %}
         {% endwith %}
-        <small>{% help href='whowasincommand/eventrec.html#incident_record_anatomy_title_area' %}</small>
+        <small>{% help href='incidentrec.html#incident-record-title-area' %}</small>
         {# All violation info uses the same source, so we can cite at the end #}
         {% cite violation.description.get_value %}
         <small class="pull-right">
@@ -78,7 +78,7 @@
 {% endblock %}
 
 {% block contents_help %}
-    <small>{% help href='whowasincommand/eventrec.html#incident_record_anatomy_content_sidebar' %}</small>
+    <small>{% help href='incidentrec.html#incident-record-content-sidebar' %}</small>
 {% endblock %}
 
 {% block sidebar %}
@@ -111,7 +111,7 @@
             <h3 id="location">
                 <i class="fa fa-fw fa-map-marker"></i>
                 {% trans "Location" %}
-                <small class="pull-right">{% help href='whowasincommand/eventrec.html#incident_record_anatomy_location' %}</small>
+                <small class="pull-right">{% help href='incidentrec.html#incident-record-location' %}</small>
             </h3>
             <hr />
             <div id="geoname_map" style="height:300px;margin-bottom:10px"></div>
@@ -137,7 +137,7 @@
             <h3 id="description" class="cited">
                 <i class="fa fa-fw fa-file-text-o"></i>
                 {% trans "Description" %}
-                <small class="pull-right">{% help href='whowasincommand/eventrec.html#incident_record_anatomy_description' %}</small>
+                <small class="pull-right">{% help href='incidentrec.html#incident-record-description' %}</small>
             </h3>
             <hr />
             {% with N=1 description=violation.description %}
@@ -191,7 +191,7 @@
                 <i class="fa fa-fw fa-users"></i>
                 {% trans "Perpetrator units" %}
                 <small class="pull-right">
-                    {% help href='whowasincommand/eventrec.html#incident_record_anatomy_perpetrator_organizations' %}
+                    {% help href='incidentrec.html#incident-record-perpetrator-units' %}
                 </small>
             </h3>
             <table class="table table-condensed">

--- a/violation/models.py
+++ b/violation/models.py
@@ -17,7 +17,7 @@ from source.models import Source
 from person.models import Person
 from organization.models import Organization
 from sfm_pc.utils import VersionsMixin
-from sfm_pc.models import GetComplexSpreadsheetFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin
 from location.models import Location
 
 
@@ -45,7 +45,7 @@ VERSION_RELATED_FIELDS = [
 
 
 @reversion.register(follow=VERSION_RELATED_FIELDS)
-class Violation(models.Model, BaseModel, VersionsMixin, GetComplexSpreadsheetFieldNameMixin):
+class Violation(models.Model, BaseModel, VersionsMixin, GetComplexFieldNameMixin):
     uuid = models.UUIDField(default=uuid.uuid4,
                             editable=False,
                             db_index=True)


### PR DESCRIPTION
## Overview

Make sure that the new field names are reflected in all public-facing views. As part of this work, update all links to external documentation to make sure they point to the updated docs.

In addition, fix a small bug #564 that is blocking the SFM team from checking sources.

Connects #662, #656, #564.

## Testing Instructions

* In working on this PR, I noticed we'd configured the Solr service incorrectly in Docker, meaning that search indexes weren't being persisted when the service was taken down. This means your Solr index probably doesn't exist, so recreate it by running `docker-compose up` in one shell and `docker-compose run --rm app ./manage.py make_search_index --recreate` in another.
* For each of personnel, units, and incidents, do:
    * Check the search page and confirm that the filters and column names match and look correct
    * Click on a detail view and confirm that the table columns also look good
    * Click on all of the help links (the grey question marks) on the page and confirm that you get taken to the proper help documentation (in each case, you should be taken to a specific section of the help page)
* Confirm the fix for the bug in #564 by visiting any detail page and opening up a citation. You should be able to click links in the citation, like the help link and the links to sources, without closing the citation popover; you should also be able to click on the body of the page outside of the citation popover to close it automatically.