### PR TITLE
Expose French translation on the frontend

### DIFF
--- a/sfm_pc/templatetags/language_url.py
+++ b/sfm_pc/templatetags/language_url.py
@@ -14,6 +14,7 @@ def create_select2_data(select_lang_abbr):
     trans_obj = {
         "en": _("English"),
         "es": _("Spanish"),
+        "fr": _("French"),
     }
     data_array = list(trans_obj.values())
     full_text = trans_obj.get(select_lang_abbr)

--- a/templates/base.html
+++ b/templates/base.html
@@ -158,6 +158,7 @@ $(document).ready(function() {
     transObj = {
         '{% trans "English" %}': 'en',
         '{% trans "Spanish" %}': 'es',
+        '{% trans "French" %}': 'fr',
     }
 
     $('.lang-select-box').on('change', function (evt) {
@@ -165,7 +166,10 @@ $(document).ready(function() {
         selectedLangSym = '/' + transObj[selectedLang] + '/';
         // Create new URL with selected language, and redirect to it.
         currentUrl = window.location.href;
-        newUrl = currentUrl.replace('/es/', selectedLangSym).replace('/en/', selectedLangSym);
+        var newUrl = currentUrl;
+        $.each(transObj, function(verboseName, slug) {
+            newUrl = newUrl.replace('/' + slug + '/', selectedLangSym);
+        });
         window.location = newUrl;
     });
 


### PR DESCRIPTION
## Overview

Expose French as a language option in the frontend for internationalization.

Connects #672. 

## Testing Instructions

* Start your development server
* Select the language box in the header and confirm `French` is an option
* Select `French` and confirm you get shown some French translations (the languages in the language selector box should change, and the search bar should say `Rechercher` instead of `Search`)
* Select the other languages in the language box and confirm that they continue to switch languages properly
