### PR TITLE
Disable sources in downloads

### DIFF
--- a/sfm_pc/downloads/areas.py
+++ b/sfm_pc/downloads/areas.py
@@ -16,31 +16,22 @@ class AreaDownload(BaseDownload):
     # Download fields
     org_id = models.UUIDField()
     name = models.TextField()
-    name_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     name_confidence = models.CharField(max_length=1)
     division_id = models.TextField()
-    division_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     division_id_confidence = models.CharField(max_length=1)
     classifications = pg_fields.ArrayField(models.TextField(), default=list)
-    classifications_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     classifications_confidence = models.CharField(max_length=1)
     aliases = pg_fields.ArrayField(models.TextField(), default=list)
-    aliases_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     aliases_confidence = models.CharField(max_length=1)
     firstciteddate = ApproximateDateField()
-    firstciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     firstciteddate_confidence = models.CharField(max_length=1)
     lastciteddate = ApproximateDateField()
-    lastciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     lastciteddate_confidence = models.CharField(max_length=1)
     realstart = models.NullBooleanField(default=None)
-    realstart_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     realstart_confidence = models.CharField(max_length=1)
     open_ended = models.CharField(max_length=1, default='N', choices=settings.OPEN_ENDED_CHOICES)
-    open_ended_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     open_ended_confidence = models.CharField(max_length=1)
     area_id = models.BigIntegerField()
-    area_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     area_id_confidence = models.CharField(max_length=1)
     area_name = models.TextField()
     area_division_id = models.TextField()
@@ -68,12 +59,6 @@ class AreaDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('name'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('name_sources', {
-                'sql': 'organization.name_sources',
-                'label': Organization.get_spreadsheet_source_field_name('name'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('name_confidence', {
                 'sql': 'organization.name_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('name'),
@@ -85,12 +70,6 @@ class AreaDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('division_id'),
                 'serializer': cls.serializers['division_id'],
             }),
-            ('division_id_sources', {
-                'sql': 'organization.division_id_sources',
-                'label': Organization.get_spreadsheet_source_field_name('division_id'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('division_id_confidence', {
                 'sql': 'organization.division_id_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('division_id'),
@@ -100,12 +79,6 @@ class AreaDownload(BaseDownload):
             ('classifications', {
                 'sql': 'organization.classifications',
                 'label': Organization.get_spreadsheet_field_name('classification'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('classifications_sources', {
-                'sql': 'organization.classifications_sources',
-                'label': Organization.get_spreadsheet_source_field_name('classification'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('classifications_confidence', {
@@ -119,12 +92,6 @@ class AreaDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('aliases'),
                 'serializer': cls.serializers['list'],
             }),
-            ('aliases_sources', {
-                'sql': 'organization.aliases_sources',
-                'label': Organization.get_spreadsheet_source_field_name('aliases'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('aliases_confidence', {
                 'sql': 'organization.aliases_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('aliases'),
@@ -135,12 +102,6 @@ class AreaDownload(BaseDownload):
                 'sql': 'organization.first_cited_date',
                 'label': Organization.get_spreadsheet_field_name('firstciteddate'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('firstciteddate_sources', {
-                'sql': 'organization.first_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('firstciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('firstciteddate_confidence', {
                 'sql': 'organization.first_cited_date_confidence',
@@ -153,12 +114,6 @@ class AreaDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('lastciteddate'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('lastciteddate_sources', {
-                'sql': 'organization.last_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('lastciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('lastciteddate_confidence', {
                 'sql': 'organization.last_cited_date_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('lastciteddate'),
@@ -169,12 +124,6 @@ class AreaDownload(BaseDownload):
                 'sql': 'organization.real_start',
                 'label': Organization.get_spreadsheet_field_name('realstart'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('realstart_sources', {
-                'sql': 'organization.real_start_sources',
-                'label': Organization.get_spreadsheet_source_field_name('realstart'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('realstart_confidence', {
                 'sql': 'organization.real_start_confidence',
@@ -187,12 +136,6 @@ class AreaDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('open_ended'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('open_ended_sources', {
-                'sql': 'organization.open_ended_sources',
-                'label': Organization.get_spreadsheet_source_field_name('open_ended'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('open_ended_confidence', {
                 'sql': 'organization.open_ended_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('open_ended'),
@@ -203,12 +146,6 @@ class AreaDownload(BaseDownload):
                 'sql': 'association.area_id',
                 'label': 'unit:area_ops_id',
                 'serializer': cls.serializers['identity'],
-            }),
-            ('area_id_sources', {
-                'sql': 'association.area_sources',
-                'label': 'unit:area_ops_id:source',
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('area_id_confidence', {
                 'sql': 'association.area_confidence',

--- a/sfm_pc/downloads/basic.py
+++ b/sfm_pc/downloads/basic.py
@@ -16,28 +16,20 @@ class BasicDownload(BaseDownload):
     # Download fields
     org_id = models.UUIDField(primary_key=True)
     name = models.TextField()
-    name_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     name_confidence = models.CharField(max_length=1)
     division_id = models.TextField()
-    division_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     division_id_confidence = models.CharField(max_length=1)
     classifications = pg_fields.ArrayField(models.TextField(), default=list)
-    classifications_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     classifications_confidence = models.CharField(max_length=1)
     aliases = pg_fields.ArrayField(models.TextField(), default=list)
-    aliases_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     aliases_confidence = models.CharField(max_length=1)
     firstciteddate = ApproximateDateField()
-    firstciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     firstciteddate_confidence = models.CharField(max_length=1)
     lastciteddate = ApproximateDateField()
-    lastciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     lastciteddate_confidence = models.CharField(max_length=1)
     realstart = models.NullBooleanField(default=None)
-    realstart_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     realstart_confidence = models.CharField(max_length=1)
     open_ended = models.CharField(max_length=1, default='N', choices=settings.OPEN_ENDED_CHOICES)
-    open_ended_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     open_ended_confidence = models.CharField(max_length=1)
 
     @classmethod
@@ -57,12 +49,6 @@ class BasicDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('name'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('name_sources', {
-                'sql': 'organization.name_sources',
-                'label': Organization.get_spreadsheet_source_field_name('name'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('name_confidence', {
                 'sql': 'organization.name_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('name'),
@@ -74,12 +60,6 @@ class BasicDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('division_id'),
                 'serializer': cls.serializers['division_id'],
             }),
-            ('division_id_sources', {
-                'sql': 'organization.division_id_sources',
-                'label': Organization.get_spreadsheet_source_field_name('division_id'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('division_id_confidence', {
                 'sql': 'organization.division_id_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('division_id'),
@@ -89,12 +69,6 @@ class BasicDownload(BaseDownload):
             ('classifications', {
                 'sql': 'organization.classifications',
                 'label': Organization.get_spreadsheet_field_name('classification'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('classifications_sources', {
-                'sql': 'organization.classifications_sources',
-                'label': Organization.get_spreadsheet_source_field_name('classification'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('classifications_confidence', {
@@ -108,12 +82,6 @@ class BasicDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('aliases'),
                 'serializer': cls.serializers['list'],
             }),
-            ('aliases_sources', {
-                'sql': 'organization.aliases_sources',
-                'label': Organization.get_spreadsheet_source_field_name('aliases'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('aliases_confidence', {
                 'sql': 'organization.aliases_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('aliases'),
@@ -124,12 +92,6 @@ class BasicDownload(BaseDownload):
                 'sql': 'organization.first_cited_date',
                 'label': Organization.get_spreadsheet_field_name('firstciteddate'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('firstciteddate_sources', {
-                'sql': 'organization.first_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('firstciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('firstciteddate_confidence', {
                 'sql': 'organization.first_cited_date_confidence',
@@ -142,12 +104,6 @@ class BasicDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('lastciteddate'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('lastciteddate_sources', {
-                'sql': 'organization.last_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('lastciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('lastciteddate_confidence', {
                 'sql': 'organization.last_cited_date_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('lastciteddate'),
@@ -159,12 +115,6 @@ class BasicDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('realstart'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('realstart_sources', {
-                'sql': 'organization.real_start_sources',
-                'label': Organization.get_spreadsheet_source_field_name('realstart'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('realstart_confidence', {
                 'sql': 'organization.real_start_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('realstart'),
@@ -175,12 +125,6 @@ class BasicDownload(BaseDownload):
                 'sql': 'organization.open_ended',
                 'label': Organization.get_spreadsheet_field_name('open_ended'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('open_ended_sources', {
-                'sql': 'organization.open_ended_sources',
-                'label': Organization.get_spreadsheet_source_field_name('open_ended'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('open_ended_confidence', {
                 'sql': 'organization.open_ended_confidence',

--- a/sfm_pc/downloads/memberships.py
+++ b/sfm_pc/downloads/memberships.py
@@ -17,52 +17,36 @@ class MembershipOrganizationDownload(BaseDownload):
     # Download fields
     org_id = models.UUIDField()
     name = models.TextField()
-    name_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     name_confidence = models.CharField(max_length=1)
     division_id = models.TextField()
-    division_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     division_id_confidence = models.CharField(max_length=1)
     classifications = pg_fields.ArrayField(models.TextField(), default=list)
-    classifications_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     classifications_confidence = models.CharField(max_length=1)
     aliases = pg_fields.ArrayField(models.TextField(), default=list)
-    aliases_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     aliases_confidence = models.CharField(max_length=1)
     firstciteddate = ApproximateDateField()
-    firstciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     firstciteddate_confidence = models.CharField(max_length=1)
     lastciteddate = ApproximateDateField()
-    lastciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     lastciteddate_confidence = models.CharField(max_length=1)
     realstart = models.NullBooleanField(default=None)
-    realstart_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     realstart_confidence = models.CharField(max_length=1)
     open_ended = models.CharField(max_length=1, default='N', choices=settings.OPEN_ENDED_CHOICES)
-    open_ended_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     open_ended_confidence = models.CharField(max_length=1)
     member_id = models.UUIDField()
-    member_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     member_id_confidence = models.CharField(max_length=1)
     member_name = models.TextField()
-    member_name_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     member_name_confidence = models.CharField(max_length=1)
     member_division_id = models.TextField()
-    member_division_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     member_division_id_confidence = models.CharField(max_length=1)
     member_classifications = pg_fields.ArrayField(models.TextField(), default=list)
-    member_classifications_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     member_classifications_confidence = models.CharField(max_length=1)
     member_firstciteddate = ApproximateDateField()
-    member_firstciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     member_firstciteddate_confidence = models.CharField(max_length=1)
     member_lastciteddate = ApproximateDateField()
-    member_lastciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     member_lastciteddate_confidence = models.CharField(max_length=1)
     member_realstart = models.NullBooleanField(default=None)
-    member_realstart_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     member_realstart_confidence = models.CharField(max_length=1)
     member_realend = models.NullBooleanField(default=None)
-    member_realend_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     member_realend_confidence = models.CharField(max_length=1)
 
     @classmethod
@@ -82,12 +66,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('name'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('name_sources', {
-                'sql': 'organization.name_sources',
-                'label': Organization.get_spreadsheet_source_field_name('name'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('name_confidence', {
                 'sql': 'organization.name_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('name'),
@@ -99,12 +77,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('division_id'),
                 'serializer': cls.serializers['division_id'],
             }),
-            ('division_id_sources', {
-                'sql': 'organization.division_id_sources',
-                'label': Organization.get_spreadsheet_source_field_name('division_id'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('division_id_confidence', {
                 'sql': 'organization.division_id_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('division_id'),
@@ -114,12 +86,6 @@ class MembershipOrganizationDownload(BaseDownload):
             ('classifications', {
                 'sql': 'organization.classifications',
                 'label': Organization.get_spreadsheet_field_name('classification'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('classifications_sources', {
-                'sql': 'organization.classifications_sources',
-                'label': Organization.get_spreadsheet_source_field_name('classification'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('classifications_confidence', {
@@ -133,12 +99,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('aliases'),
                 'serializer': cls.serializers['list'],
             }),
-            ('aliases_sources', {
-                'sql': 'organization.aliases_sources',
-                'label': Organization.get_spreadsheet_source_field_name('aliases'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('aliases_confidence', {
                 'sql': 'organization.aliases_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('aliases'),
@@ -149,12 +109,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'sql': 'organization.first_cited_date',
                 'label': Organization.get_spreadsheet_field_name('firstciteddate'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('firstciteddate_sources', {
-                'sql': 'organization.first_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('firstciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('firstciteddate_confidence', {
                 'sql': 'organization.first_cited_date_confidence',
@@ -167,12 +121,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('lastciteddate'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('lastciteddate_sources', {
-                'sql': 'organization.last_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('lastciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('lastciteddate_confidence', {
                 'sql': 'organization.last_cited_date_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('lastciteddate'),
@@ -183,12 +131,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'sql': 'organization.real_start',
                 'label': Organization.get_spreadsheet_field_name('realstart'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('realstart_sources', {
-                'sql': 'organization.real_start_sources',
-                'label': Organization.get_spreadsheet_source_field_name('realstart'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('realstart_confidence', {
                 'sql': 'organization.real_start_confidence',
@@ -201,12 +143,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('open_ended'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('open_ended_sources', {
-                'sql': 'organization.open_ended_sources',
-                'label': Organization.get_spreadsheet_source_field_name('open_ended'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('open_ended_confidence', {
                 'sql': 'organization.open_ended_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('open_ended'),
@@ -217,12 +153,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'sql': 'member.uuid',
                 'label': 'unit:membership_id',
                 'serializer': cls.serializers['string'],
-            }),
-            ('member_id_sources', {
-                'sql': 'membership.sources',
-                'label': 'unit:membership_id:source',
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('member_id_confidence', {
                 'sql': 'membership.confidence',
@@ -235,12 +165,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'label': MembershipOrganization.get_spreadsheet_field_name('organization'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('member_name_sources', {
-                'sql': 'member.name_sources',
-                'label': MembershipOrganization.get_spreadsheet_source_field_name('organization'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('member_name_confidence', {
                 'sql': 'member.name_confidence',
                 'label': MembershipOrganization.get_spreadsheet_confidence_field_name('organization'),
@@ -252,12 +176,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'label': 'unit:member_country',
                 'serializer': cls.serializers['division_id'],
             }),
-            ('member_division_id_sources', {
-                'sql': 'member.division_id_sources',
-                'label': 'unit:member_country:source',
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('member_division_id_confidence', {
                 'sql': 'member.division_id_confidence',
                 'label': 'unit:member_country:confidence',
@@ -267,12 +185,6 @@ class MembershipOrganizationDownload(BaseDownload):
             ('member_classifications', {
                 'sql': 'member.classifications',
                 'label': 'unit:member_classification',
-                'serializer': cls.serializers['list'],
-            }),
-            ('member_classifications_sources', {
-                'sql': 'member.classifications_sources',
-                'label': 'unit:member_classification:source',
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('member_classifications_confidence', {
@@ -286,12 +198,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'label': MembershipOrganization.get_spreadsheet_field_name('firstciteddate'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('member_firstciteddate_sources', {
-                'sql': 'membership.first_cited_date_sources',
-                'label': MembershipOrganization.get_spreadsheet_source_field_name('firstciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('member_firstciteddate_confidence', {
                 'sql': 'membership.first_cited_date_confidence',
                 'label': MembershipOrganization.get_spreadsheet_confidence_field_name('firstciteddate'),
@@ -302,12 +208,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'sql': 'membership.real_start',
                 'label': MembershipOrganization.get_spreadsheet_field_name('realstart'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('member_realstart_sources', {
-                'sql': 'membership.real_start_sources',
-                'label': MembershipOrganization.get_spreadsheet_source_field_name('realstart'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('member_realstart_confidence', {
                 'sql': 'membership.real_start_confidence',
@@ -320,12 +220,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'label': MembershipOrganization.get_spreadsheet_field_name('lastciteddate'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('member_lastciteddate_sources', {
-                'sql': 'membership.last_cited_date_sources',
-                'label': MembershipOrganization.get_spreadsheet_source_field_name('lastciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('member_lastciteddate_confidence', {
                 'sql': 'membership.last_cited_date_confidence',
                 'label': MembershipOrganization.get_spreadsheet_confidence_field_name('lastciteddate'),
@@ -336,12 +230,6 @@ class MembershipOrganizationDownload(BaseDownload):
                 'sql': 'membership.real_end',
                 'label': MembershipOrganization.get_spreadsheet_field_name('realend'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('member_realend_sources', {
-                'sql': 'membership.real_end_sources',
-                'label': MembershipOrganization.get_spreadsheet_source_field_name('realend'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('member_realend_confidence', {
                 'sql': 'membership.real_end_confidence',

--- a/sfm_pc/downloads/parentage.py
+++ b/sfm_pc/downloads/parentage.py
@@ -17,52 +17,36 @@ class ParentageDownload(BaseDownload):
     # Download fields
     child_unit_id = models.UUIDField()
     name = models.TextField()
-    name_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     name_confidence = models.CharField(max_length=1)
     division_id = models.TextField()
-    division_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     division_id_confidence = models.CharField(max_length=1)
     classifications = pg_fields.ArrayField(models.TextField(), default=list)
-    classifications_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     classifications_confidence = models.CharField(max_length=1)
     aliases = pg_fields.ArrayField(models.TextField(), default=list)
-    aliases_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     aliases_confidence = models.CharField(max_length=1)
     firstciteddate = ApproximateDateField()
-    firstciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     firstciteddate_confidence = models.CharField(max_length=1)
     lastciteddate = ApproximateDateField()
-    lastciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     lastciteddate_confidence = models.CharField(max_length=1)
     realstart = models.NullBooleanField(default=None)
-    realstart_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     realstart_confidence = models.CharField(max_length=1)
     open_ended = models.CharField(max_length=1, default='N', choices=settings.OPEN_ENDED_CHOICES)
-    open_ended_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     open_ended_confidence = models.CharField(max_length=1)
     related_id = models.UUIDField()
-    related_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     related_id_confidence = models.CharField(max_length=1)
     related_name = models.TextField()
-    related_name_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     related_name_confidence = models.CharField(max_length=1)
     related_division_id = models.TextField()
-    related_division_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     related_division_id_confidence = models.CharField(max_length=1)
     related_classifications = pg_fields.ArrayField(models.TextField(), default=list)
-    related_classifications_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     related_classifications_confidence = models.CharField(max_length=1)
     related_firstciteddate = ApproximateDateField()
-    related_firstciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     related_firstciteddate_confidence = models.CharField(max_length=1)
     related_lastciteddate = ApproximateDateField()
-    related_lastciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     related_lastciteddate_confidence = models.CharField(max_length=1)
     related_realstart = models.NullBooleanField(default=None)
-    related_realstart_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     related_realstart_confidence = models.CharField(max_length=1)
     related_open_ended = models.CharField(max_length=1, default='N', choices=settings.OPEN_ENDED_CHOICES)
-    related_open_ended_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     related_open_ended_confidence = models.CharField(max_length=1)
 
     @classmethod
@@ -82,12 +66,6 @@ class ParentageDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('name'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('name_sources', {
-                'sql': 'child.name_sources',
-                'label': Organization.get_spreadsheet_source_field_name('name'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('name_confidence', {
                 'sql': 'child.name_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('name'),
@@ -99,12 +77,6 @@ class ParentageDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('division_id'),
                 'serializer': cls.serializers['division_id'],
             }),
-            ('division_id_sources', {
-                'sql': 'child.division_id_sources',
-                'label': Organization.get_spreadsheet_source_field_name('division_id'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('division_id_confidence', {
                 'sql': 'child.division_id_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('division_id'),
@@ -114,12 +86,6 @@ class ParentageDownload(BaseDownload):
             ('classifications', {
                 'sql': 'child.classifications',
                 'label': Organization.get_spreadsheet_field_name('classification'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('classifications_sources', {
-                'sql': 'child.classifications_sources',
-                'label': Organization.get_spreadsheet_source_field_name('classification'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('classifications_confidence', {
@@ -133,12 +99,6 @@ class ParentageDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('aliases'),
                 'serializer': cls.serializers['list'],
             }),
-            ('aliases_sources', {
-                'sql': 'child.aliases_sources',
-                'label': Organization.get_spreadsheet_source_field_name('aliases'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('aliases_confidence', {
                 'sql': 'child.aliases_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('aliases'),
@@ -149,12 +109,6 @@ class ParentageDownload(BaseDownload):
                 'sql': 'child.first_cited_date',
                 'label': Organization.get_spreadsheet_field_name('firstciteddate'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('firstciteddate_sources', {
-                'sql': 'child.first_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('firstciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('firstciteddate_confidence', {
                 'sql': 'child.first_cited_date_confidence',
@@ -167,12 +121,6 @@ class ParentageDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('lastciteddate'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('lastciteddate_sources', {
-                'sql': 'child.last_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('lastciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('lastciteddate_confidence', {
                 'sql': 'child.last_cited_date_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('lastciteddate'),
@@ -183,12 +131,6 @@ class ParentageDownload(BaseDownload):
                 'sql': 'child.real_start',
                 'label': Organization.get_spreadsheet_field_name('realstart'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('realstart_sources', {
-                'sql': 'child.real_start_sources',
-                'label': Organization.get_spreadsheet_source_field_name('realstart'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('realstart_confidence', {
                 'sql': 'child.real_start_confidence',
@@ -201,12 +143,6 @@ class ParentageDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('open_ended'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('open_ended_sources', {
-                'sql': 'child.open_ended_sources',
-                'label': Organization.get_spreadsheet_source_field_name('open_ended'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('open_ended_confidence', {
                 'sql': 'child.open_ended_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('open_ended'),
@@ -217,12 +153,6 @@ class ParentageDownload(BaseDownload):
                 'sql': 'parent.uuid',
                 'label': Composition.get_spreadsheet_field_name('parent'),
                 'serializer': cls.serializers['string'],
-            }),
-            ('related_id_sources', {
-                'sql': "composition_parent_metadata.sources",
-                'label': Composition.get_spreadsheet_source_field_name('parent'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('related_id_confidence', {
                 'sql': "composition_parent_metadata.confidence",
@@ -235,12 +165,6 @@ class ParentageDownload(BaseDownload):
                 'label': Composition.get_spreadsheet_field_name('parent') + ':name',
                 'serializer': cls.serializers['identity'],
             }),
-            ('related_name_sources', {
-                'sql': 'parent.name_sources',
-                'label': Composition.get_spreadsheet_field_name('parent') + ':name:source',
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('related_name_confidence', {
                 'sql': 'parent.name_confidence',
                 'label': Composition.get_spreadsheet_field_name('parent') + ':name:confidence',
@@ -252,12 +176,6 @@ class ParentageDownload(BaseDownload):
                 'label': Composition.get_spreadsheet_field_name('parent') + ':country',
                 'serializer': cls.serializers['division_id'],
             }),
-            ('related_division_id_sources', {
-                'sql': 'parent.division_id_sources',
-                'label': Composition.get_spreadsheet_field_name('parent') + ':country:source',
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('related_division_id_confidence', {
                 'sql': 'parent.division_id_confidence',
                 'label': Composition.get_spreadsheet_field_name('parent') + ':country:confidence',
@@ -267,12 +185,6 @@ class ParentageDownload(BaseDownload):
             ('related_classifications', {
                 'sql': 'composition.classifications',
                 'label': Composition.get_spreadsheet_field_name('classification'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('related_classifications_sources', {
-                'sql': 'composition.classifications_sources',
-                'label': Composition.get_spreadsheet_source_field_name('classification'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('related_classifications_confidence', {
@@ -286,12 +198,6 @@ class ParentageDownload(BaseDownload):
                 'label': Composition.get_spreadsheet_field_name('startdate'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('related_firstciteddate_sources', {
-                'sql': 'composition.first_cited_date_sources',
-                'label': Composition.get_spreadsheet_source_field_name('startdate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('related_firstciteddate_confidence', {
                 'sql': 'composition.first_cited_date_confidence',
                 'label': Composition.get_spreadsheet_confidence_field_name('startdate'),
@@ -302,12 +208,6 @@ class ParentageDownload(BaseDownload):
                 'sql': 'composition.real_start',
                 'label': Composition.get_spreadsheet_field_name('realstart'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('related_realstart_sources', {
-                'sql': 'composition.real_start_sources',
-                'label': Composition.get_spreadsheet_source_field_name('realstart'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('related_realstart_confidence', {
                 'sql': 'composition.real_start_confidence',
@@ -320,12 +220,6 @@ class ParentageDownload(BaseDownload):
                 'label': Composition.get_spreadsheet_field_name('enddate'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('related_lastciteddate_sources', {
-                'sql': 'composition.last_cited_date_sources',
-                'label': Composition.get_spreadsheet_source_field_name('enddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('related_lastciteddate_confidence', {
                 'sql': 'composition.last_cited_date_confidence',
                 'label': Composition.get_spreadsheet_confidence_field_name('enddate'),
@@ -336,12 +230,6 @@ class ParentageDownload(BaseDownload):
                 'sql': 'composition.open_ended',
                 'label': Composition.get_spreadsheet_field_name('open_ended'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('related_open_ended_sources', {
-                'sql': 'composition.open_ended_sources',
-                'label': Composition.get_spreadsheet_source_field_name('open_ended'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('related_open_ended_confidence', {
                 'sql': 'composition.open_ended_confidence',

--- a/sfm_pc/downloads/personnel.py
+++ b/sfm_pc/downloads/personnel.py
@@ -20,99 +20,69 @@ class MembershipPersonDownload(BaseDownload):
     # Download fields
     org_id = models.UUIDField()
     name = models.TextField()
-    name_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     name_confidence = models.CharField(max_length=1)
     division_id = models.TextField()
-    division_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     division_id_confidence = models.CharField(max_length=1)
     classifications = pg_fields.ArrayField(models.TextField(), default=list)
-    classifications_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     classifications_confidence = models.CharField(max_length=1)
     aliases = pg_fields.ArrayField(models.TextField(), default=list)
-    aliases_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     aliases_confidence = models.CharField(max_length=1)
     firstciteddate = ApproximateDateField()
-    firstciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     firstciteddate_confidence = models.CharField(max_length=1)
     lastciteddate = ApproximateDateField()
-    lastciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     lastciteddate_confidence = models.CharField(max_length=1)
     realstart = models.NullBooleanField(default=None)
-    realstart_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     realstart_confidence = models.CharField(max_length=1)
     open_ended = models.CharField(max_length=1, default='N', choices=settings.OPEN_ENDED_CHOICES)
-    open_ended_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     open_ended_confidence = models.CharField(max_length=1)
     person_id = models.UUIDField()
-    person_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_id_confidence = models.CharField(max_length=1)
     person_name = models.TextField()
-    person_name_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_name_confidence = models.CharField(max_length=1)
     person_aliases = pg_fields.ArrayField(models.TextField(), default=list)
-    person_aliases_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_aliases_confidence = models.CharField(max_length=1)
     person_division_id = models.TextField()
-    person_division_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_division_id_confidence = models.CharField(max_length=1)
     person_date_of_birth = ApproximateDateField()
-    person_date_of_birth_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_date_of_birth_confidence = models.CharField(max_length=1)
     person_date_of_death = ApproximateDateField()
-    person_date_of_death_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_date_of_death_confidence = models.CharField(max_length=1)
     person_deceased = models.BooleanField()
-    person_deceased_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_deceased_confidence = models.CharField(max_length=1)
     person_account_types = pg_fields.ArrayField(models.TextField(), default=list)
-    person_account_types_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_account_types_confidence = models.CharField(max_length=1)
     person_accounts = pg_fields.ArrayField(models.TextField(), default=list)
-    person_accounts_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_accounts_confidence = models.CharField(max_length=1)
     person_external_link_descriptions = pg_fields.ArrayField(models.TextField(), default=list)
-    person_external_link_descriptions_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_external_link_descriptions_confidence = models.CharField(max_length=1)
     person_media_descriptions = pg_fields.ArrayField(models.TextField(), default=list)
-    person_media_descriptions_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_media_descriptions_confidence = models.CharField(max_length=1)
     person_notes = pg_fields.ArrayField(models.TextField(), default=list)
-    person_notes_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_notes_confidence = models.CharField(max_length=1)
     person_role = models.TextField()
-    person_role_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_role_confidence = models.CharField(max_length=1)
     person_rank = models.TextField()
-    person_rank_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_rank_confidence = models.CharField(max_length=1)
     person_title = models.TextField()
-    person_title_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_title_confidence = models.CharField(max_length=1)
     person_firstciteddate = ApproximateDateField()
-    person_firstciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_firstciteddate_confidence = models.CharField(max_length=1)
     person_firstciteddate_year = models.IntegerField()
     person_firstciteddate_month = models.IntegerField()
     person_firstciteddate_day = models.IntegerField()
-    person_firstciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_firstciteddate_confidence = models.CharField(max_length=1)
     person_realstart = models.NullBooleanField(default=None)
-    person_realstart_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_realstart_confidence = models.CharField(max_length=1)
     person_startcontext = models.TextField()
-    person_startcontext_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_startcontext_confidence = models.CharField(max_length=1)
     person_lastciteddate = ApproximateDateField()
-    person_lastciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_lastciteddate_confidence = models.CharField(max_length=1)
     person_lastciteddate_year = models.IntegerField()
     person_lastciteddate_month = models.IntegerField()
     person_lastciteddate_day = models.IntegerField()
     person_realend = models.NullBooleanField(default=None)
-    person_realend_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_realend_confidence = models.CharField(max_length=1)
     person_endcontext = models.TextField()
-    person_endcontext_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     person_endcontext_confidence = models.CharField(max_length=1)
 
     @classmethod
@@ -132,12 +102,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('name'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('name_sources', {
-                'sql': 'organization.name_sources',
-                'label': Organization.get_spreadsheet_source_field_name('name'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('name_confidence', {
                 'sql': 'organization.name_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('name'),
@@ -149,12 +113,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('division_id'),
                 'serializer': cls.serializers['division_id'],
             }),
-            ('division_id_sources', {
-                'sql': 'organization.division_id_sources',
-                'label': Organization.get_spreadsheet_source_field_name('division_id'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('division_id_confidence', {
                 'sql': 'organization.division_id_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('division_id'),
@@ -164,12 +122,6 @@ class MembershipPersonDownload(BaseDownload):
             ('classifications', {
                 'sql': 'organization.classifications',
                 'label': Organization.get_spreadsheet_field_name('classification'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('classifications_sources', {
-                'sql': 'organization.classifications_sources',
-                'label': Organization.get_spreadsheet_source_field_name('classification'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('classifications_confidence', {
@@ -183,12 +135,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('aliases'),
                 'serializer': cls.serializers['list'],
             }),
-            ('aliases_sources', {
-                'sql': 'organization.aliases_sources',
-                'label': Organization.get_spreadsheet_source_field_name('aliases'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('aliases_confidence', {
                 'sql': 'organization.aliases_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('aliases'),
@@ -199,12 +145,6 @@ class MembershipPersonDownload(BaseDownload):
                 'sql': 'organization.first_cited_date',
                 'label': Organization.get_spreadsheet_field_name('firstciteddate'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('firstciteddate_sources', {
-                'sql': 'organization.first_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('firstciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('firstciteddate_confidence', {
                 'sql': 'organization.first_cited_date_confidence',
@@ -217,12 +157,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('lastciteddate'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('lastciteddate_sources', {
-                'sql': 'organization.last_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('lastciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('lastciteddate_confidence', {
                 'sql': 'organization.last_cited_date_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('lastciteddate'),
@@ -233,12 +167,6 @@ class MembershipPersonDownload(BaseDownload):
                 'sql': 'organization.real_start',
                 'label': Organization.get_spreadsheet_field_name('realstart'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('realstart_sources', {
-                'sql': 'organization.real_start_sources',
-                'label': Organization.get_spreadsheet_source_field_name('realstart'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('realstart_confidence', {
                 'sql': 'organization.real_start_confidence',
@@ -251,12 +179,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('open_ended'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('open_ended_sources', {
-                'sql': 'organization.open_ended_sources',
-                'label': Organization.get_spreadsheet_source_field_name('open_ended'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('open_ended_confidence', {
                 'sql': 'organization.open_ended_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('open_ended'),
@@ -267,12 +189,6 @@ class MembershipPersonDownload(BaseDownload):
                 'sql': 'person.uuid',
                 'label': 'person:admin:id',
                 'serializer': cls.serializers['string'],
-            }),
-            ('person_id_sources', {
-                'sql': 'membership.person_id_sources',
-                'label': 'person:posting:source',
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('person_id_confidence', {
                 'sql': 'membership.person_id_confidence',
@@ -285,12 +201,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': Person.get_spreadsheet_field_name('name'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('person_name_sources', {
-                'sql': 'person.name_sources',
-                'label': Person.get_spreadsheet_source_field_name('name'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('person_name_confidence', {
                 'sql': 'person.name_confidence',
                 'label': Person.get_spreadsheet_confidence_field_name('name'),
@@ -300,12 +210,6 @@ class MembershipPersonDownload(BaseDownload):
             ('person_aliases', {
                 'sql': 'person.aliases',
                 'label': Person.get_spreadsheet_field_name('aliases'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('person_aliases_sources', {
-                'sql': 'person.aliases_sources',
-                'label': Person.get_spreadsheet_source_field_name('aliases'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('person_aliases_confidence', {
@@ -319,12 +223,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': Person.get_spreadsheet_field_name('division_id'),
                 'serializer': cls.serializers['division_id'],
             }),
-            ('person_division_id_sources', {
-                'sql': 'person.division_id_sources',
-                'label': Person.get_spreadsheet_source_field_name('division_id'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('person_division_id_confidence', {
                 'sql': 'person.division_id_confidence',
                 'label': Person.get_spreadsheet_confidence_field_name('division_id'),
@@ -334,12 +232,6 @@ class MembershipPersonDownload(BaseDownload):
             ('person_date_of_birth', {
                 'sql': 'person.date_of_birth',
                 'label': PersonBiography.get_spreadsheet_field_name('date_of_birth'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('person_date_of_birth_sources', {
-                'sql': 'person.date_of_birth_sources',
-                'label': PersonBiography.get_spreadsheet_source_field_name('date_of_birth'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('person_date_of_birth_confidence', {
@@ -353,12 +245,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': PersonBiography.get_spreadsheet_field_name('date_of_death'),
                 'serializer': cls.serializers['list'],
             }),
-            ('person_date_of_death_sources', {
-                'sql': 'person.date_of_death_sources',
-                'label': PersonBiography.get_spreadsheet_source_field_name('date_of_death'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('person_date_of_death_confidence', {
                 'sql': 'person.date_of_death_confidence',
                 'label': PersonBiography.get_spreadsheet_confidence_field_name('date_of_death'),
@@ -368,12 +254,6 @@ class MembershipPersonDownload(BaseDownload):
             ('person_deceased', {
                 'sql': 'person.deceased',
                 'label': PersonBiography.get_spreadsheet_field_name('deceased'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('person_deceased_sources', {
-                'sql': 'person.deceased_sources',
-                'label': PersonBiography.get_spreadsheet_source_field_name('deceased'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('person_deceased_confidence', {
@@ -387,12 +267,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': PersonExtra.get_spreadsheet_field_name('account_type'),
                 'serializer': cls.serializers['list'],
             }),
-            ('person_account_types_sources', {
-                'sql': 'person.account_types_sources',
-                'label': PersonExtra.get_spreadsheet_source_field_name('account_type'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('person_account_types_confidence', {
                 'sql': 'person.account_types_confidence',
                 'label': PersonExtra.get_spreadsheet_confidence_field_name('account_type'),
@@ -402,12 +276,6 @@ class MembershipPersonDownload(BaseDownload):
             ('person_accounts', {
                 'sql': 'person.accounts',
                 'label': PersonExtra.get_spreadsheet_field_name('account'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('person_accounts_sources', {
-                'sql': 'person.accounts_sources',
-                'label': PersonExtra.get_spreadsheet_source_field_name('account'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('person_accounts_confidence', {
@@ -421,12 +289,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': PersonExtra.get_spreadsheet_field_name('external_link_description'),
                 'serializer': cls.serializers['list'],
             }),
-            ('person_external_link_descriptions_sources', {
-                'sql': 'person.external_link_descriptions_sources',
-                'label': PersonExtra.get_spreadsheet_source_field_name('external_link_description'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('person_external_link_descriptions_confidence', {
                 'sql': 'person.external_link_descriptions_confidence',
                 'label': PersonExtra.get_spreadsheet_confidence_field_name('external_link_description'),
@@ -436,12 +298,6 @@ class MembershipPersonDownload(BaseDownload):
             ('person_media_descriptions', {
                 'sql': 'person.media_descriptions',
                 'label': PersonExtra.get_spreadsheet_field_name('media_description'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('person_media_descriptions_sources', {
-                'sql': 'person.media_descriptions_sources',
-                'label': PersonExtra.get_spreadsheet_source_field_name('media_description'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('person_media_descriptions_confidence', {
@@ -455,12 +311,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': PersonExtra.get_spreadsheet_field_name('notes'),
                 'serializer': cls.serializers['list'],
             }),
-            ('person_notes_sources', {
-                'sql': 'person.notes_sources',
-                'label': PersonExtra.get_spreadsheet_source_field_name('notes'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('person_notes_confidence', {
                 'sql': 'person.notes_confidence',
                 'label': PersonExtra.get_spreadsheet_confidence_field_name('notes'),
@@ -471,12 +321,6 @@ class MembershipPersonDownload(BaseDownload):
                 'sql': 'membership.role',
                 'label': MembershipPerson.get_spreadsheet_field_name('role'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('person_role_sources', {
-                'sql': 'membership.role_sources',
-                'label': MembershipPerson.get_spreadsheet_source_field_name('role'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('person_role_confidence', {
                 'sql': 'membership.role_confidence',
@@ -489,12 +333,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': MembershipPerson.get_spreadsheet_field_name('rank'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('person_rank_sources', {
-                'sql': 'membership.rank_sources',
-                'label': MembershipPerson.get_spreadsheet_source_field_name('rank'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('person_rank_confidence', {
                 'sql': 'membership.rank_confidence',
                 'label': MembershipPerson.get_spreadsheet_confidence_field_name('rank'),
@@ -505,12 +343,6 @@ class MembershipPersonDownload(BaseDownload):
                 'sql': 'membership.title',
                 'label': MembershipPerson.get_spreadsheet_field_name('title'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('person_title_sources', {
-                'sql': 'membership.title_sources',
-                'label': MembershipPerson.get_spreadsheet_source_field_name('title'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('person_title_confidence', {
                 'sql': 'membership.title_confidence',
@@ -538,12 +370,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': MembershipPerson.get_spreadsheet_field_name('firstciteddate') + ':day',
                 'serializer': cls.serializers['identity'],
             }),
-            ('person_firstciteddate_sources', {
-                'sql': 'membership.first_cited_date_sources',
-                'label': MembershipPerson.get_spreadsheet_source_field_name('firstciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('person_firstciteddate_confidence', {
                 'sql': 'membership.first_cited_date_confidence',
                 'label': MembershipPerson.get_spreadsheet_confidence_field_name('firstciteddate'),
@@ -555,12 +381,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': MembershipPerson.get_spreadsheet_field_name('realstart'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('person_realstart_sources', {
-                'sql': 'membership.real_start_sources',
-                'label': MembershipPerson.get_spreadsheet_source_field_name('realstart'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('person_realstart_confidence', {
                 'sql': 'membership.real_start_confidence',
                 'label': MembershipPerson.get_spreadsheet_confidence_field_name('realstart'),
@@ -571,12 +391,6 @@ class MembershipPersonDownload(BaseDownload):
                 'sql': 'membership.start_context',
                 'label': MembershipPerson.get_spreadsheet_field_name('startcontext'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('person_startcontext_sources', {
-                'sql': 'membership.start_context_sources',
-                'label': MembershipPerson.get_spreadsheet_source_field_name('startcontext'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('person_startcontext_confidence', {
                 'sql': 'membership.start_context_confidence',
@@ -604,12 +418,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': MembershipPerson.get_spreadsheet_field_name('lastciteddate') + ':day',
                 'serializer': cls.serializers['identity'],
             }),
-            ('person_lastciteddate_sources', {
-                'sql': 'membership.last_cited_date_sources',
-                'label': MembershipPerson.get_spreadsheet_source_field_name('lastciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('person_lastciteddate_confidence', {
                 'sql': 'membership.last_cited_date_confidence',
                 'label': MembershipPerson.get_spreadsheet_confidence_field_name('lastciteddate'),
@@ -621,12 +429,6 @@ class MembershipPersonDownload(BaseDownload):
                 'label': MembershipPerson.get_spreadsheet_field_name('realend'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('person_realend_sources', {
-                'sql': 'membership.real_end_sources',
-                'label': MembershipPerson.get_spreadsheet_source_field_name('realend'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('person_realend_confidence', {
                 'sql': 'membership.real_end_confidence',
                 'label': MembershipPerson.get_spreadsheet_confidence_field_name('realend'),
@@ -637,12 +439,6 @@ class MembershipPersonDownload(BaseDownload):
                 'sql': 'membership.end_context',
                 'label': MembershipPerson.get_spreadsheet_field_name('endcontext'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('person_endcontext_sources', {
-                'sql': 'membership.end_context_sources',
-                'label': MembershipPerson.get_spreadsheet_source_field_name('endcontext'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('person_endcontext_confidence', {
                 'sql': 'membership.end_context_confidence',

--- a/sfm_pc/downloads/sites.py
+++ b/sfm_pc/downloads/sites.py
@@ -16,31 +16,22 @@ class SiteDownload(BaseDownload):
     # Download fields
     org_id = models.UUIDField()
     name = models.TextField()
-    name_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     name_confidence = models.CharField(max_length=1)
     division_id = models.TextField()
-    division_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     division_id_confidence = models.CharField(max_length=1)
     classifications = pg_fields.ArrayField(models.TextField(), default=list)
-    classifications_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     classifications_confidence = models.CharField(max_length=1)
     aliases = pg_fields.ArrayField(models.TextField(), default=list)
-    aliases_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     aliases_confidence = models.CharField(max_length=1)
     firstciteddate = ApproximateDateField()
-    firstciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     firstciteddate_confidence = models.CharField(max_length=1)
     lastciteddate = ApproximateDateField()
-    lastciteddate_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     lastciteddate_confidence = models.CharField(max_length=1)
     realstart = models.NullBooleanField(default=None)
-    realstart_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     realstart_confidence = models.CharField(max_length=1)
     open_ended = models.CharField(max_length=1, default='N', choices=settings.OPEN_ENDED_CHOICES)
-    open_ended_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     open_ended_confidence = models.CharField(max_length=1)
     site_id = models.BigIntegerField()
-    site_id_sources = pg_fields.ArrayField(models.UUIDField(), default=list)
     site_id_confidence = models.CharField(max_length=1)
     site_name = models.TextField()
     site_division_id = models.TextField()
@@ -68,12 +59,6 @@ class SiteDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('name'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('name_sources', {
-                'sql': 'organization.name_sources',
-                'label': Organization.get_spreadsheet_source_field_name('name'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('name_confidence', {
                 'sql': 'organization.name_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('name'),
@@ -85,12 +70,6 @@ class SiteDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('division_id'),
                 'serializer': cls.serializers['division_id'],
             }),
-            ('division_id_sources', {
-                'sql': 'organization.division_id_sources',
-                'label': Organization.get_spreadsheet_source_field_name('division_id'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('division_id_confidence', {
                 'sql': 'organization.division_id_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('division_id'),
@@ -100,12 +79,6 @@ class SiteDownload(BaseDownload):
             ('classifications', {
                 'sql': 'organization.classifications',
                 'label': Organization.get_spreadsheet_field_name('classification'),
-                'serializer': cls.serializers['list'],
-            }),
-            ('classifications_sources', {
-                'sql': 'organization.classifications_sources',
-                'label': Organization.get_spreadsheet_source_field_name('classification'),
-                'source': True,
                 'serializer': cls.serializers['list'],
             }),
             ('classifications_confidence', {
@@ -119,12 +92,6 @@ class SiteDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('aliases'),
                 'serializer': cls.serializers['list'],
             }),
-            ('aliases_sources', {
-                'sql': 'organization.aliases_sources',
-                'label': Organization.get_spreadsheet_source_field_name('aliases'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('aliases_confidence', {
                 'sql': 'organization.aliases_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('aliases'),
@@ -135,12 +102,6 @@ class SiteDownload(BaseDownload):
                 'sql': 'organization.first_cited_date',
                 'label': Organization.get_spreadsheet_field_name('firstciteddate'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('firstciteddate_sources', {
-                'sql': 'organization.first_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('firstciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('firstciteddate_confidence', {
                 'sql': 'organization.first_cited_date_confidence',
@@ -153,12 +114,6 @@ class SiteDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('lastciteddate'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('lastciteddate_sources', {
-                'sql': 'organization.last_cited_date_sources',
-                'label': Organization.get_spreadsheet_source_field_name('lastciteddate'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('lastciteddate_confidence', {
                 'sql': 'organization.last_cited_date_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('lastciteddate'),
@@ -169,12 +124,6 @@ class SiteDownload(BaseDownload):
                 'sql': 'organization.real_start',
                 'label': Organization.get_spreadsheet_field_name('realstart'),
                 'serializer': cls.serializers['identity'],
-            }),
-            ('realstart_sources', {
-                'sql': 'organization.real_start_sources',
-                'label': Organization.get_spreadsheet_source_field_name('realstart'),
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('realstart_confidence', {
                 'sql': 'organization.real_start_confidence',
@@ -187,12 +136,6 @@ class SiteDownload(BaseDownload):
                 'label': Organization.get_spreadsheet_field_name('open_ended'),
                 'serializer': cls.serializers['identity'],
             }),
-            ('open_ended_sources', {
-                'sql': 'organization.open_ended_sources',
-                'label': Organization.get_spreadsheet_source_field_name('open_ended'),
-                'source': True,
-                'serializer': cls.serializers['list'],
-            }),
             ('open_ended_confidence', {
                 'sql': 'organization.open_ended_confidence',
                 'label': Organization.get_spreadsheet_confidence_field_name('open_ended'),
@@ -203,12 +146,6 @@ class SiteDownload(BaseDownload):
                 'sql': 'location.id',
                 'label': 'unit:site_exact_location_id_latitude',
                 'serializer': cls.serializers['identity'],
-            }),
-            ('site_id_sources', {
-                'sql': 'emplacement.site_sources',
-                'label': 'unit:site_exact_location:source',
-                'source': True,
-                'serializer': cls.serializers['list'],
             }),
             ('site_id_confidence', {
                 'sql': 'emplacement.site_confidence',

--- a/sfm_pc/downloads/sql/areas.sql
+++ b/sfm_pc/downloads/sql/areas.sql
@@ -9,80 +9,53 @@ WITH filtered_organization AS (
       MAX(object_ref.uuid::text) AS uuid,
       MAX(name.value) AS name,
       MAX(name.confidence) AS name_confidence,
-      array_agg(DISTINCT name_sources.accesspoint_id) AS name_sources,
       MAX(division_id.value) AS division_id,
       MAX(division_id.confidence) AS division_id_confidence,
-      array_agg(DISTINCT division_id_sources.accesspoint_id) AS division_id_sources,
       array_agg(DISTINCT classifications.value) AS classifications,
       MAX(classifications.confidence) AS classifications_confidence,
-      array_agg(DISTINCT classifications_sources.accesspoint_id) AS classifications_sources,
       array_agg(DISTINCT aliases.value) AS aliases,
       MAX(aliases.confidence) AS aliases_confidence,
-      array_agg(DISTINCT aliases_sources.accesspoint_id) AS aliases_sources,
       MAX(firstciteddate.value) AS first_cited_date,
       MAX(firstciteddate.confidence) AS first_cited_date_confidence,
-      array_agg(DISTINCT firstciteddate_sources.accesspoint_id) AS first_cited_date_sources,
       MAX(lastciteddate.value) AS last_cited_date,
       MAX(lastciteddate.confidence) AS last_cited_date_confidence,
-      array_agg(DISTINCT lastciteddate_sources.accesspoint_id) AS last_cited_date_sources,
       CASE
         WHEN bool_and(realstart.value) = true THEN 'Y'
         WHEN bool_and(realstart.value) = false THEN 'N'
         ELSE '' END
       AS real_start,
       MAX(realstart.confidence) AS real_start_confidence,
-      array_agg(DISTINCT realstart_sources.accesspoint_id) AS real_start_sources,
       MAX(open_ended.value) AS open_ended,
-      MAX(open_ended.confidence) AS open_ended_confidence,
-      array_agg(DISTINCT open_ended_sources.accesspoint_id) AS open_ended_sources
+      MAX(open_ended.confidence) AS open_ended_confidence
     FROM organization_organization AS object_ref
     JOIN organization_organizationname AS name
       ON object_ref.id = name.object_ref_id
-    LEFT JOIN organization_organizationname_accesspoints AS name_sources
-      ON name.id = name_sources.organizationname_id
     JOIN organization_organizationdivisionid AS division_id
       ON object_ref.id = division_id.object_ref_id
-    LEFT JOIN organization_organizationdivisionid_accesspoints AS division_id_sources
-      ON division_id.id = division_id_sources.organizationdivisionid_id
     LEFT JOIN organization_organizationclassification AS classifications
       ON object_ref.id = classifications.object_ref_id
-    LEFT JOIN organization_organizationclassification_accesspoints AS classifications_sources
-      ON classifications.id = classifications_sources.organizationclassification_id
     LEFT JOIN organization_organizationalias AS aliases
       ON object_ref.id = aliases.object_ref_id
-    LEFT JOIN organization_organizationalias_accesspoints AS aliases_sources
-      ON aliases.id = aliases_sources.organizationalias_id
     LEFT JOIN organization_organizationfirstciteddate AS firstciteddate
       ON object_ref.id = firstciteddate.object_ref_id
-    LEFT JOIN organization_organizationfirstciteddate_accesspoints AS firstciteddate_sources
-      ON firstciteddate.id = firstciteddate_sources.organizationfirstciteddate_id
     LEFT JOIN organization_organizationlastciteddate AS lastciteddate
       ON object_ref.id = lastciteddate.object_ref_id
-    LEFT JOIN organization_organizationlastciteddate_accesspoints AS lastciteddate_sources
-      ON lastciteddate.id = lastciteddate_sources.organizationlastciteddate_id
     LEFT JOIN organization_organizationrealstart AS realstart
       ON object_ref.id = realstart.object_ref_id
-    LEFT JOIN organization_organizationrealstart_accesspoints AS realstart_sources
-      ON realstart.id = realstart_sources.organizationrealstart_id
     LEFT JOIN organization_organizationopenended AS open_ended
       ON object_ref.id = open_ended.object_ref_id
-    LEFT JOIN organization_organizationopenended_accesspoints AS open_ended_sources
-      ON open_ended.id = open_ended_sources.organizationopenended_id
     GROUP BY object_ref.id
   ), association AS (
     SELECT
       association_organization.value_id AS organization_id,
       association.id AS id,
       MAX(location.id) AS area_id,
-      MAX(area.confidence) AS area_confidence,
-      array_agg(DISTINCT association_sources.accesspoint_id) AS area_sources
+      MAX(area.confidence) AS area_confidence
     FROM association_associationorganization AS association_organization
     JOIN association_association AS association
       ON association_organization.object_ref_id = association.id
     JOIN association_associationarea AS area
       ON association.id = area.object_ref_id
-    JOIN association_associationarea_accesspoints AS association_sources
-      ON area.id = association_sources.associationarea_id
     JOIN location_location AS location
       ON area.value_id = location.id
     GROUP BY association_organization.value_id, association.id

--- a/sfm_pc/downloads/sql/basic.sql
+++ b/sfm_pc/downloads/sql/basic.sql
@@ -9,65 +9,41 @@ WITH filtered_organization AS (
       MAX(object_ref.uuid::text) AS uuid,
       MAX(name.value) AS name,
       MAX(name.confidence) AS name_confidence,
-      array_agg(DISTINCT name_sources.accesspoint_id) AS name_sources,
       MAX(division_id.value) AS division_id,
       MAX(division_id.confidence) AS division_id_confidence,
-      array_agg(DISTINCT division_id_sources.accesspoint_id) AS division_id_sources,
       array_agg(DISTINCT classifications.value) AS classifications,
       MAX(classifications.confidence) AS classifications_confidence,
-      array_agg(DISTINCT classifications_sources.accesspoint_id) AS classifications_sources,
       array_agg(DISTINCT aliases.value) AS aliases,
       MAX(aliases.confidence) AS aliases_confidence,
-      array_agg(DISTINCT aliases_sources.accesspoint_id) AS aliases_sources,
       MAX(firstciteddate.value) AS first_cited_date,
       MAX(firstciteddate.confidence) AS first_cited_date_confidence,
-      array_agg(DISTINCT firstciteddate_sources.accesspoint_id) AS first_cited_date_sources,
       MAX(lastciteddate.value) AS last_cited_date,
       MAX(lastciteddate.confidence) AS last_cited_date_confidence,
-      array_agg(DISTINCT lastciteddate_sources.accesspoint_id) AS last_cited_date_sources,
       CASE
         WHEN bool_and(realstart.value) = true THEN 'Y'
         WHEN bool_and(realstart.value) = false THEN 'N'
         ELSE '' END
       AS real_start,
       MAX(realstart.confidence) AS real_start_confidence,
-      array_agg(DISTINCT realstart_sources.accesspoint_id) AS real_start_sources,
       MAX(open_ended.value) AS open_ended,
-      MAX(open_ended.confidence) AS open_ended_confidence,
-      array_agg(DISTINCT open_ended_sources.accesspoint_id) AS open_ended_sources
+      MAX(open_ended.confidence) AS open_ended_confidence
     FROM organization_organization AS object_ref
     JOIN organization_organizationname AS name
       ON object_ref.id = name.object_ref_id
-    LEFT JOIN organization_organizationname_accesspoints AS name_sources
-      ON name.id = name_sources.organizationname_id
     JOIN organization_organizationdivisionid AS division_id
       ON object_ref.id = division_id.object_ref_id
-    LEFT JOIN organization_organizationdivisionid_accesspoints AS division_id_sources
-      ON division_id.id = division_id_sources.organizationdivisionid_id
     LEFT JOIN organization_organizationclassification AS classifications
       ON object_ref.id = classifications.object_ref_id
-    LEFT JOIN organization_organizationclassification_accesspoints AS classifications_sources
-      ON classifications.id = classifications_sources.organizationclassification_id
     LEFT JOIN organization_organizationalias AS aliases
       ON object_ref.id = aliases.object_ref_id
-    LEFT JOIN organization_organizationalias_accesspoints AS aliases_sources
-      ON aliases.id = aliases_sources.organizationalias_id
     LEFT JOIN organization_organizationfirstciteddate AS firstciteddate
       ON object_ref.id = firstciteddate.object_ref_id
-    LEFT JOIN organization_organizationfirstciteddate_accesspoints AS firstciteddate_sources
-      ON firstciteddate.id = firstciteddate_sources.organizationfirstciteddate_id
     LEFT JOIN organization_organizationlastciteddate AS lastciteddate
       ON object_ref.id = lastciteddate.object_ref_id
-    LEFT JOIN organization_organizationlastciteddate_accesspoints AS lastciteddate_sources
-      ON lastciteddate.id = lastciteddate_sources.organizationlastciteddate_id
     LEFT JOIN organization_organizationrealstart AS realstart
       ON object_ref.id = realstart.object_ref_id
-    LEFT JOIN organization_organizationrealstart_accesspoints AS realstart_sources
-      ON realstart.id = realstart_sources.organizationrealstart_id
     LEFT JOIN organization_organizationopenended AS open_ended
       ON object_ref.id = open_ended.object_ref_id
-    LEFT JOIN organization_organizationopenended_accesspoints AS open_ended_sources
-      ON open_ended.id = open_ended_sources.organizationopenended_id
     GROUP BY object_ref.id
   )
 SELECT

--- a/sfm_pc/downloads/sql/memberships.sql
+++ b/sfm_pc/downloads/sql/memberships.sql
@@ -9,115 +9,76 @@ WITH filtered_organization AS (
       MAX(object_ref.uuid::text) AS uuid,
       MAX(name.value) AS name,
       MAX(name.confidence) AS name_confidence,
-      array_agg(DISTINCT name_sources.accesspoint_id) AS name_sources,
       MAX(division_id.value) AS division_id,
       MAX(division_id.confidence) AS division_id_confidence,
-      array_agg(DISTINCT division_id_sources.accesspoint_id) AS division_id_sources,
       array_agg(DISTINCT classifications.value) AS classifications,
       MAX(classifications.confidence) AS classifications_confidence,
-      array_agg(DISTINCT classifications_sources.accesspoint_id) AS classifications_sources,
       array_agg(DISTINCT aliases.value) AS aliases,
       MAX(aliases.confidence) AS aliases_confidence,
-      array_agg(DISTINCT aliases_sources.accesspoint_id) AS aliases_sources,
       MAX(firstciteddate.value) AS first_cited_date,
       MAX(firstciteddate.confidence) AS first_cited_date_confidence,
-      array_agg(DISTINCT firstciteddate_sources.accesspoint_id) AS first_cited_date_sources,
       MAX(lastciteddate.value) AS last_cited_date,
       MAX(lastciteddate.confidence) AS last_cited_date_confidence,
-      array_agg(DISTINCT lastciteddate_sources.accesspoint_id) AS last_cited_date_sources,
       CASE
         WHEN bool_and(realstart.value) = true THEN 'Y'
         WHEN bool_and(realstart.value) = false THEN 'N'
         ELSE '' END
       AS real_start,
       MAX(realstart.confidence) AS real_start_confidence,
-      array_agg(DISTINCT realstart_sources.accesspoint_id) AS real_start_sources,
       MAX(open_ended.value) AS open_ended,
-      MAX(open_ended.confidence) AS open_ended_confidence,
-      array_agg(DISTINCT open_ended_sources.accesspoint_id) AS open_ended_sources
+      MAX(open_ended.confidence) AS open_ended_confidence
     FROM organization_organization AS object_ref
     JOIN organization_organizationname AS name
       ON object_ref.id = name.object_ref_id
-    LEFT JOIN organization_organizationname_accesspoints AS name_sources
-      ON name.id = name_sources.organizationname_id
     JOIN organization_organizationdivisionid AS division_id
       ON object_ref.id = division_id.object_ref_id
-    LEFT JOIN organization_organizationdivisionid_accesspoints AS division_id_sources
-      ON division_id.id = division_id_sources.organizationdivisionid_id
     LEFT JOIN organization_organizationclassification AS classifications
       ON object_ref.id = classifications.object_ref_id
-    LEFT JOIN organization_organizationclassification_accesspoints AS classifications_sources
-      ON classifications.id = classifications_sources.organizationclassification_id
     LEFT JOIN organization_organizationalias AS aliases
       ON object_ref.id = aliases.object_ref_id
-    LEFT JOIN organization_organizationalias_accesspoints AS aliases_sources
-      ON aliases.id = aliases_sources.organizationalias_id
     LEFT JOIN organization_organizationfirstciteddate AS firstciteddate
       ON object_ref.id = firstciteddate.object_ref_id
-    LEFT JOIN organization_organizationfirstciteddate_accesspoints AS firstciteddate_sources
-      ON firstciteddate.id = firstciteddate_sources.organizationfirstciteddate_id
     LEFT JOIN organization_organizationlastciteddate AS lastciteddate
       ON object_ref.id = lastciteddate.object_ref_id
-    LEFT JOIN organization_organizationlastciteddate_accesspoints AS lastciteddate_sources
-      ON lastciteddate.id = lastciteddate_sources.organizationlastciteddate_id
     LEFT JOIN organization_organizationrealstart AS realstart
       ON object_ref.id = realstart.object_ref_id
-    LEFT JOIN organization_organizationrealstart_accesspoints AS realstart_sources
-      ON realstart.id = realstart_sources.organizationrealstart_id
     LEFT JOIN organization_organizationopenended AS open_ended
       ON object_ref.id = open_ended.object_ref_id
-    LEFT JOIN organization_organizationopenended_accesspoints AS open_ended_sources
-      ON open_ended.id = open_ended_sources.organizationopenended_id
     GROUP BY object_ref.id
   ), membership AS (
     SELECT
       membership.value_id AS organization_id,
       member_organization.value_id AS member_id,
-      array_agg(DISTINCT member_organization_sources.accesspoint_id) AS sources,
       MAX(member_organization.confidence) AS confidence,
       MAX(first_cited_date.value) AS first_cited_date,
       MAX(first_cited_date.confidence) AS first_cited_date_confidence,
-      array_agg(DISTINCT first_cited_date_sources.accesspoint_id) AS first_cited_date_sources,
       CASE
         WHEN bool_and(real_start.value) = true THEN 'Y'
         WHEN bool_and(real_start.value) = false THEN 'N'
         ELSE '' END
       AS real_start,
       MAX(real_start.confidence) AS real_start_confidence,
-      array_agg(DISTINCT real_start_sources.accesspoint_id) AS real_start_sources,
       MAX(last_cited_date.value) AS last_cited_date,
       MAX(last_cited_date.confidence) AS last_cited_date_confidence,
-      array_agg(DISTINCT last_cited_date_sources.accesspoint_id) AS last_cited_date_sources,
       CASE
         WHEN bool_and(real_end.value) = true THEN 'Y'
         WHEN bool_and(real_end.value) = false THEN 'N'
         ELSE '' END
       AS real_end,
-      MAX(real_end.confidence) AS real_end_confidence,
-      array_agg(DISTINCT real_end_sources.accesspoint_id) AS real_end_sources
+      MAX(real_end.confidence) AS real_end_confidence
     FROM membershiporganization_m AS membership
     JOIN membershiporganization_membershiporganization AS member_object_ref
       ON membership.object_ref_id = member_object_ref.id
     LEFT JOIN membershiporganization_moo AS member_organization
       ON member_object_ref.id = member_organization.object_ref_id
-    LEFT JOIN membershiporganization_moo_accesspoints AS member_organization_sources
-      ON member_organization.id = member_organization_sources.membershiporganizationorganization_id
     LEFT JOIN membershiporganization_fcd AS first_cited_date
       ON member_object_ref.id = first_cited_date.object_ref_id
-    LEFT JOIN membershiporganization_fcd_accesspoints AS first_cited_date_sources
-      ON first_cited_date.id = first_cited_date_sources.membershiporganizationfirstciteddate_id
     LEFT JOIN membershiporganization_lcd AS last_cited_date
       ON member_object_ref.id = last_cited_date.object_ref_id
-    LEFT JOIN membershiporganization_lcd_accesspoints AS last_cited_date_sources
-      ON last_cited_date.id = last_cited_date_sources.membershiporganizationlastciteddate_id
     LEFT JOIN membershiporganization_membershiporganizationrealstart AS real_start
       ON member_object_ref.id = real_start.object_ref_id
-    LEFT JOIN membershiporganization_membershiporganizationrealstart_acceac5c AS real_start_sources
-      ON real_start.id = real_start_sources.membershiporganizationrealstart_id
     LEFT JOIN membershiporganization_membershiporganizationrealend AS real_end
       ON member_object_ref.id = real_end.object_ref_id
-    LEFT JOIN membershiporganization_membershiporganizationrealend_access5a60 AS real_end_sources
-      ON real_end.id = real_end_sources.membershiporganizationrealend_id
     GROUP BY membership.value_id, member_organization.value_id
   )
 SELECT

--- a/sfm_pc/downloads/sql/parentage.sql
+++ b/sfm_pc/downloads/sql/parentage.sql
@@ -9,118 +9,76 @@ WITH filtered_organization AS (
       MAX(object_ref.uuid::text) AS uuid,
       MAX(name.value) AS name,
       MAX(name.confidence) AS name_confidence,
-      array_agg(DISTINCT name_sources.accesspoint_id) AS name_sources,
       MAX(division_id.value) AS division_id,
       MAX(division_id.confidence) AS division_id_confidence,
-      array_agg(DISTINCT division_id_sources.accesspoint_id) AS division_id_sources,
       array_agg(DISTINCT classifications.value) AS classifications,
       MAX(classifications.confidence) AS classifications_confidence,
-      array_agg(DISTINCT classifications_sources.accesspoint_id) AS classifications_sources,
       array_agg(DISTINCT aliases.value) AS aliases,
       MAX(aliases.confidence) AS aliases_confidence,
-      array_agg(DISTINCT aliases_sources.accesspoint_id) AS aliases_sources,
       MAX(firstciteddate.value) AS first_cited_date,
       MAX(firstciteddate.confidence) AS first_cited_date_confidence,
-      array_agg(DISTINCT firstciteddate_sources.accesspoint_id) AS first_cited_date_sources,
       MAX(lastciteddate.value) AS last_cited_date,
       MAX(lastciteddate.confidence) AS last_cited_date_confidence,
-      array_agg(DISTINCT lastciteddate_sources.accesspoint_id) AS last_cited_date_sources,
       CASE
         WHEN bool_and(realstart.value) = true THEN 'Y'
         WHEN bool_and(realstart.value) = false THEN 'N'
         ELSE '' END
       AS real_start,
       MAX(realstart.confidence) AS real_start_confidence,
-      array_agg(DISTINCT realstart_sources.accesspoint_id) AS real_start_sources,
       MAX(open_ended.value) AS open_ended,
-      MAX(open_ended.confidence) AS open_ended_confidence,
-      array_agg(DISTINCT open_ended_sources.accesspoint_id) AS open_ended_sources
+      MAX(open_ended.confidence) AS open_ended_confidence
     FROM organization_organization AS object_ref
     JOIN organization_organizationname AS name
       ON object_ref.id = name.object_ref_id
-    LEFT JOIN organization_organizationname_accesspoints AS name_sources
-      ON name.id = name_sources.organizationname_id
     JOIN organization_organizationdivisionid AS division_id
       ON object_ref.id = division_id.object_ref_id
-    LEFT JOIN organization_organizationdivisionid_accesspoints AS division_id_sources
-      ON division_id.id = division_id_sources.organizationdivisionid_id
     LEFT JOIN organization_organizationclassification AS classifications
       ON object_ref.id = classifications.object_ref_id
-    LEFT JOIN organization_organizationclassification_accesspoints AS classifications_sources
-      ON classifications.id = classifications_sources.organizationclassification_id
     LEFT JOIN organization_organizationalias AS aliases
       ON object_ref.id = aliases.object_ref_id
-    LEFT JOIN organization_organizationalias_accesspoints AS aliases_sources
-      ON aliases.id = aliases_sources.organizationalias_id
     LEFT JOIN organization_organizationfirstciteddate AS firstciteddate
       ON object_ref.id = firstciteddate.object_ref_id
-    LEFT JOIN organization_organizationfirstciteddate_accesspoints AS firstciteddate_sources
-      ON firstciteddate.id = firstciteddate_sources.organizationfirstciteddate_id
     LEFT JOIN organization_organizationlastciteddate AS lastciteddate
       ON object_ref.id = lastciteddate.object_ref_id
-    LEFT JOIN organization_organizationlastciteddate_accesspoints AS lastciteddate_sources
-      ON lastciteddate.id = lastciteddate_sources.organizationlastciteddate_id
     LEFT JOIN organization_organizationrealstart AS realstart
       ON object_ref.id = realstart.object_ref_id
-    LEFT JOIN organization_organizationrealstart_accesspoints AS realstart_sources
-      ON realstart.id = realstart_sources.organizationrealstart_id
     LEFT JOIN organization_organizationopenended AS open_ended
       ON object_ref.id = open_ended.object_ref_id
-    LEFT JOIN organization_organizationopenended_accesspoints AS open_ended_sources
-      ON open_ended.id = open_ended_sources.organizationopenended_id
     GROUP BY object_ref.id
   ), composition AS (
     SELECT
       comp_object_ref.id AS id,
       array_agg(DISTINCT comp_classification.value) AS classifications,
       MAX(comp_classification.confidence) AS classifications_confidence,
-      array_agg(DISTINCT comp_classification_sources.accesspoint_id) AS classifications_sources,
       MAX(comp_firstciteddate.value) AS first_cited_date,
       MAX(comp_firstciteddate.confidence) AS first_cited_date_confidence,
-      array_agg(DISTINCT comp_firstciteddate_sources.accesspoint_id) AS first_cited_date_sources,
       CASE
         WHEN bool_and(comp_realstart.value) = true THEN 'Y'
         WHEN bool_and(comp_realstart.value) = false THEN 'N'
         ELSE '' END
       AS real_start,
       MAX(comp_realstart.confidence) AS real_start_confidence,
-      array_agg(DISTINCT comp_realstart_sources.accesspoint_id) AS real_start_sources,
       MAX(comp_lastciteddate.value) AS last_cited_date,
       MAX(comp_lastciteddate.confidence) AS last_cited_date_confidence,
-      array_agg(DISTINCT comp_lastciteddate_sources.accesspoint_id) AS last_cited_date_sources,
       MAX(comp_openended.value) AS open_ended,
-      MAX(comp_openended.confidence) AS open_ended_confidence,
-      array_agg(DISTINCT comp_openended_sources.accesspoint_id) AS open_ended_sources
+      MAX(comp_openended.confidence) AS open_ended_confidence
     FROM composition_composition AS comp_object_ref
     LEFT JOIN composition_compositionclassification AS comp_classification
       ON comp_object_ref.id = comp_classification.object_ref_id
-    LEFT JOIN composition_compositionclassification_accesspoints AS comp_classification_sources
-      ON comp_classification.id = comp_classification_sources.compositionclassification_id
     LEFT JOIN composition_compositionstartdate AS comp_firstciteddate
       ON comp_object_ref.id = comp_firstciteddate.object_ref_id
-    LEFT JOIN composition_compositionstartdate_accesspoints AS comp_firstciteddate_sources
-      ON comp_firstciteddate.id = comp_firstciteddate_sources.compositionstartdate_id
     LEFT JOIN composition_compositionenddate AS comp_lastciteddate
       ON comp_object_ref.id = comp_lastciteddate.object_ref_id
-    LEFT JOIN composition_compositionenddate_accesspoints AS comp_lastciteddate_sources
-      ON comp_lastciteddate.id = comp_lastciteddate_sources.compositionenddate_id
     LEFT JOIN composition_compositionrealstart AS comp_realstart
       ON comp_object_ref.id = comp_realstart.object_ref_id
-    LEFT JOIN composition_compositionrealstart_accesspoints AS comp_realstart_sources
-      ON comp_realstart.id = comp_realstart_sources.compositionrealstart_id
     LEFT JOIN composition_compositionopenended AS comp_openended
       ON comp_object_ref.id = comp_openended.object_ref_id
-    LEFT JOIN composition_compositionopenended_accesspoints AS comp_openended_sources
-      ON comp_openended.id = comp_openended_sources.compositionopenended_id
     GROUP BY comp_object_ref.id
   ), composition_parent_metadata AS (
     SELECT
       composition_parent.id AS id,
-      MAX(composition_parent.confidence) AS confidence,
-      array_agg(DISTINCT composition_parent_sources.accesspoint_id) AS sources
+      MAX(composition_parent.confidence) AS confidence
     FROM composition_compositionparent AS composition_parent
-    LEFT JOIN composition_compositionparent_accesspoints AS composition_parent_sources
-      ON composition_parent.id = composition_parent_sources.compositionparent_id
     GROUP BY composition_parent.id
   )
 SELECT

--- a/sfm_pc/downloads/sql/personnel.sql
+++ b/sfm_pc/downloads/sql/personnel.sql
@@ -9,65 +9,41 @@ WITH filtered_organization AS (
       MAX(object_ref.uuid::text) AS uuid,
       MAX(name.value) AS name,
       MAX(name.confidence) AS name_confidence,
-      array_agg(DISTINCT name_sources.accesspoint_id) AS name_sources,
       MAX(division_id.value) AS division_id,
       MAX(division_id.confidence) AS division_id_confidence,
-      array_agg(DISTINCT division_id_sources.accesspoint_id) AS division_id_sources,
       array_agg(DISTINCT classifications.value) AS classifications,
       MAX(classifications.confidence) AS classifications_confidence,
-      array_agg(DISTINCT classifications_sources.accesspoint_id) AS classifications_sources,
       array_agg(DISTINCT aliases.value) AS aliases,
       MAX(aliases.confidence) AS aliases_confidence,
-      array_agg(DISTINCT aliases_sources.accesspoint_id) AS aliases_sources,
       MAX(firstciteddate.value) AS first_cited_date,
       MAX(firstciteddate.confidence) AS first_cited_date_confidence,
-      array_agg(DISTINCT firstciteddate_sources.accesspoint_id) AS first_cited_date_sources,
       MAX(lastciteddate.value) AS last_cited_date,
       MAX(lastciteddate.confidence) AS last_cited_date_confidence,
-      array_agg(DISTINCT lastciteddate_sources.accesspoint_id) AS last_cited_date_sources,
       CASE
         WHEN bool_and(realstart.value) = true THEN 'Y'
         WHEN bool_and(realstart.value) = false THEN 'N'
         ELSE '' END
       AS real_start,
       MAX(realstart.confidence) AS real_start_confidence,
-      array_agg(DISTINCT realstart_sources.accesspoint_id) AS real_start_sources,
       MAX(open_ended.value) AS open_ended,
-      MAX(open_ended.confidence) AS open_ended_confidence,
-      array_agg(DISTINCT open_ended_sources.accesspoint_id) AS open_ended_sources
+      MAX(open_ended.confidence) AS open_ended_confidence
     FROM organization_organization AS object_ref
     JOIN organization_organizationname AS name
       ON object_ref.id = name.object_ref_id
-    LEFT JOIN organization_organizationname_accesspoints AS name_sources
-      ON name.id = name_sources.organizationname_id
     JOIN organization_organizationdivisionid AS division_id
       ON object_ref.id = division_id.object_ref_id
-    LEFT JOIN organization_organizationdivisionid_accesspoints AS division_id_sources
-      ON division_id.id = division_id_sources.organizationdivisionid_id
     LEFT JOIN organization_organizationclassification AS classifications
       ON object_ref.id = classifications.object_ref_id
-    LEFT JOIN organization_organizationclassification_accesspoints AS classifications_sources
-      ON classifications.id = classifications_sources.organizationclassification_id
     LEFT JOIN organization_organizationalias AS aliases
       ON object_ref.id = aliases.object_ref_id
-    LEFT JOIN organization_organizationalias_accesspoints AS aliases_sources
-      ON aliases.id = aliases_sources.organizationalias_id
     LEFT JOIN organization_organizationfirstciteddate AS firstciteddate
       ON object_ref.id = firstciteddate.object_ref_id
-    LEFT JOIN organization_organizationfirstciteddate_accesspoints AS firstciteddate_sources
-      ON firstciteddate.id = firstciteddate_sources.organizationfirstciteddate_id
     LEFT JOIN organization_organizationlastciteddate AS lastciteddate
       ON object_ref.id = lastciteddate.object_ref_id
-    LEFT JOIN organization_organizationlastciteddate_accesspoints AS lastciteddate_sources
-      ON lastciteddate.id = lastciteddate_sources.organizationlastciteddate_id
     LEFT JOIN organization_organizationrealstart AS realstart
       ON object_ref.id = realstart.object_ref_id
-    LEFT JOIN organization_organizationrealstart_accesspoints AS realstart_sources
-      ON realstart.id = realstart_sources.organizationrealstart_id
     LEFT JOIN organization_organizationopenended AS open_ended
       ON object_ref.id = open_ended.object_ref_id
-    LEFT JOIN organization_organizationopenended_accesspoints AS open_ended_sources
-      ON open_ended.id = open_ended_sources.organizationopenended_id
     GROUP BY object_ref.id
   ), filtered_person AS (
     SELECT
@@ -80,192 +56,126 @@ WITH filtered_organization AS (
       MAX(person.uuid::text) AS uuid,
       MAX(person_name.value) AS name,
       MAX(person_name.confidence) AS name_confidence,
-      array_agg(DISTINCT person_name_sources.accesspoint_id) AS name_sources,
       array_agg(DISTINCT person_alias.value) AS aliases,
       MAX(person_alias.confidence) AS aliases_confidence,
-      array_agg(DISTINCT person_alias_sources.accesspoint_id) AS aliases_sources,
       MAX(person_division_id.value) AS division_id,
       MAX(person_division_id.confidence) AS division_id_confidence,
-      array_agg(DISTINCT person_division_id_sources.accesspoint_id) AS division_id_sources,
       MAX(person_date_of_birth.value) AS date_of_birth,
       MAX(person_date_of_birth.confidence) AS date_of_birth_confidence,
-      array_agg(DISTINCT person_date_of_birth_sources.accesspoint_id) AS date_of_birth_sources,
       MAX(person_date_of_death.value) AS date_of_death,
       MAX(person_date_of_death.confidence) AS date_of_death_confidence,
-      array_agg(DISTINCT person_date_of_death_sources.accesspoint_id) AS date_of_death_sources,
       bool_and(person_deceased.value) AS deceased,
       MAX(person_deceased.confidence) AS deceased_confidence,
-      array_agg(DISTINCT person_deceased_sources.accesspoint_id) AS deceased_sources,
       MAX(person_gender.value) AS gender,
       MAX(person_gender.confidence) AS gender_confidence,
-      array_agg(DISTINCT person_gender_sources.accesspoint_id) AS gender_sources,
       array_agg(DISTINCT person_account_type.value) AS account_types,
       MAX(person_account_type.confidence) AS account_types_confidence,
-      array_agg(DISTINCT person_account_type_sources.accesspoint_id) AS account_types_sources,
       array_agg(DISTINCT person_account.value) AS accounts,
       MAX(person_account_type.confidence) AS accounts_confidence,
-      array_agg(DISTINCT person_account_sources.accesspoint_id) AS accounts_sources,
       array_agg(DISTINCT person_external_link_description.value) AS external_link_descriptions,
       MAX(person_external_link_description.confidence) AS external_link_descriptions_confidence,
-      array_agg(DISTINCT person_external_link_description_sources.accesspoint_id) AS external_link_descriptions_sources,
       array_agg(DISTINCT person_media_description.value) AS media_descriptions,
       MAX(person_media_description.confidence) AS media_descriptions_confidence,
-      array_agg(DISTINCT person_media_description_sources.accesspoint_id) AS media_descriptions_sources,
       array_agg(DISTINCT person_notes.value) AS notes,
-      MAX(person_notes.confidence) AS notes_confidence,
-      array_agg(DISTINCT person_notes_sources.accesspoint_id) AS notes_sources
+      MAX(person_notes.confidence) AS notes_confidence
     FROM person_person AS person
     JOIN person_personname AS person_name
       ON person.id = person_name.object_ref_id
-    LEFT JOIN person_personname_accesspoints AS person_name_sources
-      ON person_name.id = person_name_sources.personname_id
     LEFT JOIN person_persondivisionid as person_division_id
       ON person.id = person_division_id.id
-    LEFT JOIN person_persondivisionid_accesspoints AS person_division_id_sources
-      ON person_division_id.id = person_division_id_sources.persondivisionid_id
     LEFT JOIN person_personalias AS person_alias
       ON person.id = person_alias.object_ref_id
-    LEFT JOIN person_personalias_accesspoints AS person_alias_sources
-      ON person_alias.id = person_alias_sources.personalias_id
     LEFT JOIN personbiography_personbiographyperson AS person_biography_person
       ON person.id = person_biography_person.value_id
     LEFT JOIN personbiography_personbiography AS person_biography
       ON person_biography_person.object_ref_id = person_biography.id
     LEFT JOIN personbiography_personbiographydateofbirth AS person_date_of_birth
       ON person_biography.id = person_date_of_birth.object_ref_id
-    LEFT JOIN personbiography_personbiographydateofbirth_accesspoints AS person_date_of_birth_sources
-      ON person_date_of_birth.id = person_date_of_birth_sources.personbiographydateofbirth_id
     LEFT JOIN personbiography_personbiographydateofdeath AS person_date_of_death
       ON person_biography.id = person_date_of_death.object_ref_id
-    LEFT JOIN personbiography_personbiographydateofdeath_accesspoints AS person_date_of_death_sources
-      ON person_date_of_death.id = person_date_of_death_sources.personbiographydateofdeath_id
     LEFT JOIN personbiography_personbiographygender AS person_gender
       ON person_biography.id = person_gender.object_ref_id
-    LEFT JOIN personbiography_personbiographygender_accesspoints AS person_gender_sources
-      ON person_gender.id = person_gender_sources.personbiographygender_id
     LEFT JOIN personbiography_personbiographydeceased AS person_deceased
       ON person_biography.id = person_deceased.object_ref_id
-    LEFT JOIN personbiography_personbiographydeceased_accesspoints AS person_deceased_sources
-      ON person_deceased.id = person_deceased_sources.personbiographydeceased_id
     LEFT JOIN personextra_personextraperson AS person_extra_person
       ON person.id = person_extra_person.value_id
     LEFT JOIN personextra_personextra AS person_extra
       ON person_extra_person.object_ref_id = person_extra.id
     LEFT JOIN personextra_personextraaccounttype AS person_account_type
       ON person_extra.id = person_account_type.object_ref_id
-    LEFT JOIN personextra_personextraaccounttype_accesspoints AS person_account_type_sources
-      ON person_account_type.id = person_account_type_sources.personextraaccounttype_id
     LEFT JOIN personextra_personextraaccount AS person_account
       ON person_extra.id = person_account.object_ref_id
-    LEFT JOIN personextra_personextraaccount_accesspoints AS person_account_sources
-      ON person_account.id = person_account_sources.personextraaccount_id
     LEFT JOIN personextra_personextraexternallinkdescription AS person_external_link_description
       ON person_extra.id = person_external_link_description.object_ref_id
-    LEFT JOIN personextra_personextraexternallinkdescription_accesspoints AS person_external_link_description_sources
-      ON person_external_link_description.id = person_external_link_description_sources.personextraexternallinkdescription_id
     LEFT JOIN personextra_personextramediadescription AS person_media_description
       ON person_extra.id = person_media_description.object_ref_id
-    LEFT JOIN personextra_personextramediadescription_accesspoints AS person_media_description_sources
-      ON person_media_description.id = person_media_description_sources.personextramediadescription_id
     LEFT JOIN personextra_personextranotes AS person_notes
       ON person_extra.id = person_notes.object_ref_id
-    LEFT JOIN personextra_personextranotes_accesspoints AS person_notes_sources
-      ON person_notes.id = person_notes_sources.personextranotes_id
     GROUP BY person.id
   ), membership AS (
     SELECT
       membership_organization.value_id AS organization_id,
       member.value_id AS person_id,
       MAX(member.confidence) AS person_id_confidence,
-      array_agg(DISTINCT member_sources.accesspoint_id) AS person_id_sources,
       MAX(person_role.value) AS role,
       MAX(role.confidence) AS role_confidence,
-      array_agg(DISTINCT role_sources.accesspoint_id) AS role_sources,
       MAX(person_rank.value) AS rank,
       MAX(rank.confidence) AS rank_confidence,
-      array_agg(DISTINCT rank_sources.accesspoint_id) AS rank_sources,
       MAX(person_title.value) AS title,
       MAX(person_title.confidence) AS title_confidence,
-      array_agg(DISTINCT title_sources.accesspoint_id) AS title_sources,
       MAX(person_first_cited_date.value) AS first_cited_date,
       split_part(MAX(person_first_cited_date.value), '-', 1) As first_cited_date_year,
       split_part(MAX(person_first_cited_date.value), '-', 2) As first_cited_date_month,
       split_part(MAX(person_first_cited_date.value), '-', 3) As first_cited_date_day,
       MAX(person_first_cited_date.confidence) AS first_cited_date_confidence,
-      array_agg(DISTINCT person_first_cited_date_sources.accesspoint_id) AS first_cited_date_sources,
       CASE
         WHEN bool_and(person_real_start.value) = true THEN 'Y'
         WHEN bool_and(person_real_start.value) = false THEN 'N'
         ELSE '' END
       AS real_start,
       MAX(person_real_start.confidence) AS real_start_confidence,
-      array_agg(DISTINCT person_real_start_sources.accesspoint_id) AS real_start_sources,
       MAX(person_start_context.value) AS start_context,
       MAX(person_start_context.confidence) AS start_context_confidence,
-      array_agg(DISTINCT person_start_context_sources.accesspoint_id) AS start_context_sources,
       MAX(person_last_cited_date.value) AS last_cited_date,
       split_part(MAX(person_last_cited_date.value), '-', 1) As last_cited_date_year,
       split_part(MAX(person_last_cited_date.value), '-', 2) As last_cited_date_month,
       split_part(MAX(person_last_cited_date.value), '-', 3) As last_cited_date_day,
       MAX(person_last_cited_date.confidence) AS last_cited_date_confidence,
-      array_agg(DISTINCT person_last_cited_date_sources.accesspoint_id) AS last_cited_date_sources,
       CASE
         WHEN bool_and(person_real_end.value) = true THEN 'Y'
         WHEN bool_and(person_real_end.value) = false THEN 'N'
         ELSE '' END
       AS real_end,
       MAX(person_real_end.confidence) AS real_end_confidence,
-      array_agg(DISTINCT person_real_end_sources.accesspoint_id) AS real_end_sources,
       MAX(person_end_context.value) AS end_context,
-      MAX(person_end_context.confidence) AS end_context_confidence,
-      array_agg(DISTINCT person_end_context_sources.accesspoint_id) AS end_context_sources
+      MAX(person_end_context.confidence) AS end_context_confidence
     FROM membershipperson_membershippersonorganization AS membership_organization
     JOIN membershipperson_membershipperson AS membership
       ON membership_organization.object_ref_id = membership.id
     JOIN membershipperson_membershippersonmember AS member
       ON membership.id = member.object_ref_id
-    LEFT JOIN membershipperson_membershippersonmember_accesspoints AS member_sources
-      ON member.id = member_sources.membershippersonmember_id
     LEFT JOIN membershipperson_membershippersonrole AS role
       ON membership.id = role.object_ref_id
     JOIN membershipperson_role AS person_role
       ON role.value_id = person_role.id
-    LEFT JOIN membershipperson_membershippersonrole_accesspoints AS role_sources
-      ON role.id = role_sources.membershippersonrole_id
     LEFT JOIN membershipperson_membershippersonrank AS rank
       ON membership.id = rank.object_ref_id
     JOIN membershipperson_rank AS person_rank
       ON rank.value_id = person_rank.id
-    LEFT JOIN membershipperson_membershippersonrank_accesspoints AS rank_sources
-      ON rank.id = rank_sources.membershippersonrank_id
     LEFT JOIN membershipperson_membershippersontitle AS person_title
       ON membership.id = person_title.object_ref_id
-    LEFT JOIN membershipperson_membershippersontitle_accesspoints AS title_sources
-      ON person_title.id = title_sources.membershippersontitle_id
     LEFT JOIN membershipperson_membershippersonlastciteddate AS person_last_cited_date
       ON membership.id = person_last_cited_date.object_ref_id
-    LEFT JOIN membershipperson_membershippersonlastciteddate_accesspoints AS person_last_cited_date_sources
-      ON person_last_cited_date.id = person_last_cited_date_sources.membershippersonlastciteddate_id
     LEFT JOIN membershipperson_membershippersonfirstciteddate AS person_first_cited_date
       ON membership.id = person_first_cited_date.object_ref_id
-    LEFT JOIN membershipperson_membershippersonfirstciteddate_accesspoints AS person_first_cited_date_sources
-      ON person_first_cited_date.id = person_first_cited_date_sources.membershippersonfirstciteddate_id
     LEFT JOIN membershipperson_membershippersonstartcontext AS person_start_context
       ON membership.id = person_start_context.object_ref_id
-    LEFT JOIN membershipperson_membershippersonstartcontext_accesspoints AS person_start_context_sources
-      ON person_start_context.id = person_start_context_sources.membershippersonstartcontext_id
     LEFT JOIN membershipperson_membershippersonendcontext AS person_end_context
       ON membership.id = person_end_context.object_ref_id
-    LEFT JOIN membershipperson_membershippersonendcontext_accesspoints AS person_end_context_sources
-      ON person_end_context.id = person_end_context_sources.membershippersonendcontext_id
     LEFT JOIN membershipperson_membershippersonrealstart AS person_real_start
       ON membership.id = person_real_start.object_ref_id
-    LEFT JOIN membershipperson_membershippersonrealstart_accesspoints AS person_real_start_sources
-      ON person_real_start.id = person_real_start_sources.membershippersonrealstart_id
     LEFT JOIN membershipperson_membershippersonrealend AS person_real_end
       ON membership.id = person_real_end.object_ref_id
-    LEFT JOIN membershipperson_membershippersonrealend_accesspoints AS person_real_end_sources
-      ON person_real_end.id = person_real_end_sources.membershippersonrealend_id
     GROUP BY membership_organization.value_id, member.value_id
   )
 SELECT

--- a/sfm_pc/downloads/sql/sites.sql
+++ b/sfm_pc/downloads/sql/sites.sql
@@ -9,80 +9,53 @@ WITH filtered_organization AS (
       MAX(object_ref.uuid::text) AS uuid,
       MAX(name.value) AS name,
       MAX(name.confidence) AS name_confidence,
-      array_agg(DISTINCT name_sources.accesspoint_id) AS name_sources,
       MAX(division_id.value) AS division_id,
       MAX(division_id.confidence) AS division_id_confidence,
-      array_agg(DISTINCT division_id_sources.accesspoint_id) AS division_id_sources,
       array_agg(DISTINCT classifications.value) AS classifications,
       MAX(classifications.confidence) AS classifications_confidence,
-      array_agg(DISTINCT classifications_sources.accesspoint_id) AS classifications_sources,
       array_agg(DISTINCT aliases.value) AS aliases,
       MAX(aliases.confidence) AS aliases_confidence,
-      array_agg(DISTINCT aliases_sources.accesspoint_id) AS aliases_sources,
       MAX(firstciteddate.value) AS first_cited_date,
       MAX(firstciteddate.confidence) AS first_cited_date_confidence,
-      array_agg(DISTINCT firstciteddate_sources.accesspoint_id) AS first_cited_date_sources,
       MAX(lastciteddate.value) AS last_cited_date,
       MAX(lastciteddate.confidence) AS last_cited_date_confidence,
-      array_agg(DISTINCT lastciteddate_sources.accesspoint_id) AS last_cited_date_sources,
       CASE
         WHEN bool_and(realstart.value) = true THEN 'Y'
         WHEN bool_and(realstart.value) = false THEN 'N'
         ELSE '' END
       AS real_start,
       MAX(realstart.confidence) AS real_start_confidence,
-      array_agg(DISTINCT realstart_sources.accesspoint_id) AS real_start_sources,
       MAX(open_ended.value) AS open_ended,
-      MAX(open_ended.confidence) AS open_ended_confidence,
-      array_agg(DISTINCT open_ended_sources.accesspoint_id) AS open_ended_sources
+      MAX(open_ended.confidence) AS open_ended_confidence
     FROM organization_organization AS object_ref
     JOIN organization_organizationname AS name
       ON object_ref.id = name.object_ref_id
-    LEFT JOIN organization_organizationname_accesspoints AS name_sources
-      ON name.id = name_sources.organizationname_id
     JOIN organization_organizationdivisionid AS division_id
       ON object_ref.id = division_id.object_ref_id
-    LEFT JOIN organization_organizationdivisionid_accesspoints AS division_id_sources
-      ON division_id.id = division_id_sources.organizationdivisionid_id
     LEFT JOIN organization_organizationclassification AS classifications
       ON object_ref.id = classifications.object_ref_id
-    LEFT JOIN organization_organizationclassification_accesspoints AS classifications_sources
-      ON classifications.id = classifications_sources.organizationclassification_id
     LEFT JOIN organization_organizationalias AS aliases
       ON object_ref.id = aliases.object_ref_id
-    LEFT JOIN organization_organizationalias_accesspoints AS aliases_sources
-      ON aliases.id = aliases_sources.organizationalias_id
     LEFT JOIN organization_organizationfirstciteddate AS firstciteddate
       ON object_ref.id = firstciteddate.object_ref_id
-    LEFT JOIN organization_organizationfirstciteddate_accesspoints AS firstciteddate_sources
-      ON firstciteddate.id = firstciteddate_sources.organizationfirstciteddate_id
     LEFT JOIN organization_organizationlastciteddate AS lastciteddate
       ON object_ref.id = lastciteddate.object_ref_id
-    LEFT JOIN organization_organizationlastciteddate_accesspoints AS lastciteddate_sources
-      ON lastciteddate.id = lastciteddate_sources.organizationlastciteddate_id
     LEFT JOIN organization_organizationrealstart AS realstart
       ON object_ref.id = realstart.object_ref_id
-    LEFT JOIN organization_organizationrealstart_accesspoints AS realstart_sources
-      ON realstart.id = realstart_sources.organizationrealstart_id
     LEFT JOIN organization_organizationopenended AS open_ended
       ON object_ref.id = open_ended.object_ref_id
-    LEFT JOIN organization_organizationopenended_accesspoints AS open_ended_sources
-      ON open_ended.id = open_ended_sources.organizationopenended_id
     GROUP BY object_ref.id
   ), emplacement AS (
     SELECT
       emplacement_organization.value_id AS organization_id,
       emplacement.id AS id,
       MAX(location.id) AS site_id,
-      MAX(site.confidence) AS site_confidence,
-      array_agg(DISTINCT emplacement_sources.accesspoint_id) AS site_sources
+      MAX(site.confidence) AS site_confidence
     FROM emplacement_emplacementorganization AS emplacement_organization
     JOIN emplacement_emplacement AS emplacement
       ON emplacement_organization.object_ref_id = emplacement.id
     JOIN emplacement_emplacementsite AS site
       ON emplacement.id = site.object_ref_id
-    JOIN emplacement_emplacementsite_accesspoints AS emplacement_sources
-      ON site.id = emplacement_sources.emplacementsite_id
     JOIN location_location AS location
       ON site.value_id = location.id
     GROUP BY emplacement_organization.value_id, emplacement.id

--- a/sfm_pc/forms.py
+++ b/sfm_pc/forms.py
@@ -563,7 +563,6 @@ def download_types():
 class DownloadForm(forms.Form):
     download_type = forms.ChoiceField(label=gettext_lazy("Choose a download type"), choices=download_types)
     division_id = forms.ChoiceField(label=gettext_lazy("Country"), choices=division_choices)
-    sources = forms.BooleanField(label=gettext_lazy("Include sources"), required=False)
     confidences = forms.BooleanField(label=gettext_lazy("Include confidence scores"), required=False)
 
 

--- a/sfm_pc/views.py
+++ b/sfm_pc/views.py
@@ -237,7 +237,6 @@ class DownloadData(FormView):
 
         download_type = form.cleaned_data['download_type']
         division_id = form.cleaned_data['division_id']
-        sources = form.cleaned_data['sources']
         confidences = form.cleaned_data['confidences']
 
         download_class = download_classes[download_type]
@@ -252,14 +251,12 @@ class DownloadData(FormView):
         if download_type == 'sources':
             return download_class.render_to_csv_response(
                 filename,
-                sources=sources,
                 confidences=confidences
             )
         else:
             return download_class.render_to_csv_response(
                 filename,
                 division_id=division_id,
-                sources=sources,
                 confidences=confidences
             )
 

--- a/templates/download.html
+++ b/templates/download.html
@@ -50,30 +50,6 @@
         </div>
         <div class="row">
             <div class="col-sm-12">
-            {% if form.sources.errors %}
-                <div class="form-group has-error has-feedback">
-            {% else %}
-                <div class="form-group">
-            {% endif %}
-                    <div class="checkbox">
-                        <label class="control-label">
-                            <input type="checkbox" name="sources" id="id_sources">
-                            {{ form.fields.sources.label }}
-                        </label>
-                    </div>
-                    {% if form.sources.errors %}
-                        {% for error in form.sources.errors %}
-                            <span class="help-block">
-                                <i class="fa fa-remove"></i>
-                                {{ error }}
-                            </span>
-                        {% endfor %}
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-sm-12">
             {% if form.confidences.errors %}
                 <div class="form-group has-error has-feedback">
             {% else %}


### PR DESCRIPTION
## Overview

Disable the option to include sources in downloads. See the notes for some background on why we're making this change.

Connects #661 

### Notes

It turns out the queries that we use to create materialized views for downloads require too much disk space to run on the production database. (Disk space is required for temporary tables that are created to handle joins at query time.) We initially ran into this problem with the smaller subset of Mexico data and were able to fix it by splitting the query into subqueries such that we could perform filtering in a separate subquery and then join it to the main query; this worked for Mexico, but did not scale up to production. To test a fix locally, I downloaded a dump of the production database and restored it locally.

The fact that removing sources as done in this PR fixes the problem and reduces the amount of time it takes to run the queries from hours to a couple of seconds indicates to me that the highly normalized nature of the sources tables is the root problem here. Since each source attribute represents a many-to-many relationship and has its own table, including sources not only doubles the joins, but greatly increases the complexity of the query. But figuring out exactly how to join them properly will take somewhere between 4-8 hours and consultation with Forest, so for now we're going to disable the feature.

## Testing Instructions

* Run `docker-compose run --rm app ./manage.py make_materialized_views` and confirm that all the queries run successfully
* Navigate to http://localhost:8000/en/download and make sure you can download each download type for one given geography (I tested Mexico)
