### PR TITLE
Restyle country selector and populate it from search index

### DIFF
--- a/sfm_pc/urls.py
+++ b/sfm_pc/urls.py
@@ -31,7 +31,7 @@ urlpatterns = i18n_patterns(
     url(r'^command-chain/(?P<org_id>[0-9a-f-]+)/(?P<when>[0-9-]+)/$', cache_page(60 * 60 * 24)(command_chain), name="command-chain-bounded"),
 
     # Dashboard
-    url(r'^$', Dashboard.as_view(), name='dashboard'),
+    url(r'^$', cache_page(60 * 60 * 24)(Dashboard.as_view()), name='dashboard'),
 
     # Admin panel
     url(r'^admin/', include(admin.site.urls)),

--- a/templates/sfm/dashboard.html
+++ b/templates/sfm/dashboard.html
@@ -62,8 +62,8 @@
                                     </strong>
                                 </p>
                             </div>
-                            <div class="col-xs-12 col-sm-6">
-                                <select name="selected_facets">
+                            <div class="col-xs-12 col-sm-8">
+                                <select name="selected_facets" id="country-select" style="height:36px">
                                     <option value="">{% trans "Select a country" %}</option>
                                     {% for country in countries %}
                                         <option value="country_ss_fct_exact:{{ country}}">{{ country }}</option>
@@ -106,6 +106,10 @@
 <script>
 
     $('document').ready(function() {
+        // Enable select2 for country selector dropdown and set its height equal
+        // to the entity selector buttons
+        $('#country-select').select2({ width: '100%'});
+        $('#select2-country-select-container').parent('span.select2-selection').css('height', '36px');
 
         // Autofocus input on older browsers
         if (!("autofocus" in document.createElement("input"))) {


### PR DESCRIPTION
## Overview

Make a couple small tweaks to the country selector on the homepage, including:

- Populate it from the search index instead of the `OSM_DATA` config variable
- Sort the options alphabetically
- Adjust the height to match the entity selector buttons

Connects #687.

## Testing Instructions

- Navigate to http://localhost:8000
- Confirm that the country options are sorted alphabetically
- Try a few of the options and confirm that they have results in the search index
- Check the height of the country selector and confirm it matches the entity selector buttons to the left