### PR TITLE
Fix apparent duplicate memberships

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -565,7 +565,7 @@ def membership_person(access_points, people, organizations):
 
     memberships = []
 
-    for member in people[:2]:
+    for member, organization in zip(people[:2], organizations[:2]):
 
         rank = Rank.objects.create(value='Commander')
         role = Role.objects.create(value='Honcho')
@@ -577,7 +577,7 @@ def membership_person(access_points, people, organizations):
                 'confidence': '1',
             },
             'MembershipPerson_MembershipPersonOrganization': {
-                'value': organizations[0],
+                'value': organization,
                 'sources': access_points,
                 'confidence': '1',
             },
@@ -622,6 +622,15 @@ def membership_person(access_points, people, organizations):
         }
 
         memberships.append(MembershipPerson.create(mem_info))
+
+    # Create an additional membership that is the same as the last one, just
+    # with a different title, for testing apparent duplicates
+    mem_info['MembershipPerson_MembershipPersonTitle'] = {
+        'value': 'Second Title',
+        'sources': access_points,
+        'confidence': '1',
+    }
+    memberships.append(MembershipPerson.create(mem_info))
 
     return memberships
 

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -31,7 +31,8 @@ def expected_entity_names(emplacement,
         composition[0].child.get_value().value.name.get_value().value,
         truncatewords(violation.description.get_value(), 10),
         membership_organization.organization.get_value().value.name.get_value().value,
-    ] + [mem.member.get_value().value.name.get_value().value for mem in membership_person]
+        membership_person[0].member.get_value().value.name.get_value().value
+    ]
 
 
 @pytest.mark.django_db

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -9,6 +9,7 @@ from django.template.defaultfilters import truncatewords
 
 from source.models import AccessPoint
 from person.models import Person
+from person.views import get_commanders
 from organization.models import Organization
 from membershipperson.models import MembershipPerson, Rank, Role
 from tests.conftest import is_tab_active
@@ -688,3 +689,16 @@ def test_person_edit_buttons(setUp, people, membership_person):
             )
         ),
         'Postings')
+
+
+@pytest.mark.django_db
+def test_get_commanders_ignores_title(setUp, access_points, people, membership_person, organizations, composition):
+    """
+    get_commanders() should ignore memberships that are identical except for
+    title. Use the fact that we set up such a membership in the membership_person
+    fixture to test to make sure get_commanders() only returns one commander.
+    """
+    person_id = people[0].uuid
+    child_compositions = composition[0].parent.get_value().value.child_organization.all()
+    commanders = get_commanders(None, None, child_compositions, person_id)
+    assert len(commanders) == 1


### PR DESCRIPTION
## Overview

Adjust `person.views.get_commanders()` to ignore title when finding unique commanders.

Connects #697.

## Testing Instructions

* Ensure new test passes
