### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
         python-version: '3.6'
     - name: Install dependencies
       run: |
+        sudo apt update
+        sudo apt install -y gdal-bin
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Test with pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - deploy
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:9.6-2.5
+        env:
+          POSTGRES_DB: sfm
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgis://postgres:postgres@localhost:5432/sfm
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        # Semantic version range syntax or exact version of a Python version
+        python-version: '3.6'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test with pytest
+      run: |
+        pytest -sv
+  deploy:
+    needs: test
+    name: Deploy to AWS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - uses: actions/checkout@v2
+      - id: deploy
+        uses: webfactory/create-aws-codedeploy-deployment@0.2.2
+        with:
+          application: whowasincommand

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,12 @@
 branches:
   only:
   - master
-  - "/^v[0-9].*$/"
 
 language: python
 python: '3.6'
 
 dist: trusty
 sudo: false
-
-addons:
-  postgresql: '9.6'
-
-  apt:
-    packages:
-    - postgresql-9.6-postgis-2.3
-
-install:
-- pip install -r requirements.txt
-
-script:
-- pytest tests
 
 deploy:
   - provider: codedeploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,27 +29,6 @@ deploy:
       secure: lzkkBz2rEAO5Ya1d1PTl3UANQyu7oqWMBqeehaoH+50DyHVPjCwNb+osJTxbQBdiqdos8GMAR5VRziUCaNO9UZMFLHbRuJAmqwj5+DyMemhUpqkMJLwGP4apwEDdf7F3EJzt0z12Ej7y2UpZrr2y3LReX9y3NPkYFdGm2HelHszrd9+ruSSRw7TAWXJJqn/O0G0joPXaPGyW90T3PPp96nqw88ritQ0VjKj3bcoELf8qPqA0eROhVZ4Cqo8JRPj4oyGW35jKTbiv8TONRxH0hsxg0TLu/bSJy5jj6mB9Rcrz6zR4NDm4CBb4d0PmOf1Eq22j4XQK8k/q3J+GBQLMmd0zKMOpPa0cL+JFGK4fkb7pb3Q6SDAw/6y2/U0/HoLSndHJiBn6oJFX0EOF9EfFUNxxUa33OaB/4/XMo8sKypQSw6wyfQzrXP0lrQy3XotAh48T/crNuRY8qZJnP8lbw28XLE/giJGWnpOfhHHEoIAqyyvnoS7cTY+gW+uvVW7DODWIg2uT12wbNrYVJOqIIs4Pw7BbxXUlbkNyLNQs0cS46SZ10oFNrECaRm7U+oIz0FCNqASex0MrZ5QJDkt665dBxv2CcvAnmu2PQtleWvka2Sa3tDfkvXOLV0EF9vCiVMBIRjzGuwThJFi9pAFS8DLU5jmSpI/1YRT/4cDnHi4=
     revision_type: github
     application: whowasincommand
-    deployment_group: staging
-    on:
-      branch:
-        - master
-
-  - provider: codedeploy
-    access_key_id: AKIAI6FQEBXYL562GLLA
-    secret_access_key:
-      secure: lzkkBz2rEAO5Ya1d1PTl3UANQyu7oqWMBqeehaoH+50DyHVPjCwNb+osJTxbQBdiqdos8GMAR5VRziUCaNO9UZMFLHbRuJAmqwj5+DyMemhUpqkMJLwGP4apwEDdf7F3EJzt0z12Ej7y2UpZrr2y3LReX9y3NPkYFdGm2HelHszrd9+ruSSRw7TAWXJJqn/O0G0joPXaPGyW90T3PPp96nqw88ritQ0VjKj3bcoELf8qPqA0eROhVZ4Cqo8JRPj4oyGW35jKTbiv8TONRxH0hsxg0TLu/bSJy5jj6mB9Rcrz6zR4NDm4CBb4d0PmOf1Eq22j4XQK8k/q3J+GBQLMmd0zKMOpPa0cL+JFGK4fkb7pb3Q6SDAw/6y2/U0/HoLSndHJiBn6oJFX0EOF9EfFUNxxUa33OaB/4/XMo8sKypQSw6wyfQzrXP0lrQy3XotAh48T/crNuRY8qZJnP8lbw28XLE/giJGWnpOfhHHEoIAqyyvnoS7cTY+gW+uvVW7DODWIg2uT12wbNrYVJOqIIs4Pw7BbxXUlbkNyLNQs0cS46SZ10oFNrECaRm7U+oIz0FCNqASex0MrZ5QJDkt665dBxv2CcvAnmu2PQtleWvka2Sa3tDfkvXOLV0EF9vCiVMBIRjzGuwThJFi9pAFS8DLU5jmSpI/1YRT/4cDnHi4=
-    revision_type: github
-    application: whowasincommand
-    deployment_group: production
-    on:
-      tags: true
-
-  - provider: codedeploy
-    access_key_id: AKIAI6FQEBXYL562GLLA
-    secret_access_key:
-      secure: lzkkBz2rEAO5Ya1d1PTl3UANQyu7oqWMBqeehaoH+50DyHVPjCwNb+osJTxbQBdiqdos8GMAR5VRziUCaNO9UZMFLHbRuJAmqwj5+DyMemhUpqkMJLwGP4apwEDdf7F3EJzt0z12Ej7y2UpZrr2y3LReX9y3NPkYFdGm2HelHszrd9+ruSSRw7TAWXJJqn/O0G0joPXaPGyW90T3PPp96nqw88ritQ0VjKj3bcoELf8qPqA0eROhVZ4Cqo8JRPj4oyGW35jKTbiv8TONRxH0hsxg0TLu/bSJy5jj6mB9Rcrz6zR4NDm4CBb4d0PmOf1Eq22j4XQK8k/q3J+GBQLMmd0zKMOpPa0cL+JFGK4fkb7pb3Q6SDAw/6y2/U0/HoLSndHJiBn6oJFX0EOF9EfFUNxxUa33OaB/4/XMo8sKypQSw6wyfQzrXP0lrQy3XotAh48T/crNuRY8qZJnP8lbw28XLE/giJGWnpOfhHHEoIAqyyvnoS7cTY+gW+uvVW7DODWIg2uT12wbNrYVJOqIIs4Pw7BbxXUlbkNyLNQs0cS46SZ10oFNrECaRm7U+oIz0FCNqASex0MrZ5QJDkt665dBxv2CcvAnmu2PQtleWvka2Sa3tDfkvXOLV0EF9vCiVMBIRjzGuwThJFi9pAFS8DLU5jmSpI/1YRT/4cDnHi4=
-    revision_type: github
-    application: whowasincommand
     deployment_group: sahel
     on:
       branch:

--- a/appspec.yml
+++ b/appspec.yml
@@ -20,3 +20,9 @@ hooks: # these are boilerplate and may be copy/pasted as is
     - location: scripts/after_install.sh
       timeout: 2700
       runas: root
+
+branch_config:
+  master:
+    deploymentGroupName: staging
+  deploy:
+    deploymentGroupName: production

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,8 +18,6 @@ from django.utils.translation import ugettext_lazy as _
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-DATABASE_URL = os.getenv('DATABASE_URL', 'postgis://postgres@localhost:5432/sfm')
-
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY='super duper secret'
 
@@ -108,6 +106,7 @@ WSGI_APPLICATION = 'sfm_pc.wsgi.application'
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 
 # Parse database configuration from $DATABASE_URL
+DATABASE_URL = os.getenv('DATABASE_URL', 'postgis://postgres@localhost:5432/sfm')
 DATABASES = {'default': dj_database_url.parse(DATABASE_URL)}
 DATABASES['default']['ENGINE'] = 'django.contrib.gis.db.backends.postgis'
 


### PR DESCRIPTION
## Overview

Travis CI builds take forever. This PR adds CI with GitHub Actions. N.b., our preferred tooling for AWS deployments cannot accommodate deploying to multiple deployment groups from a single branch, so I've left the Travis config in place for the Sahel instance. Once I've confirmed GitHub Actions runs the tests as expected, I'll disable Travis builds for PRs. The effect will be Travis will no longer run tests redundant with GHA against pull requests or merges, but it will deploy code merged into master (which will have been tested via GHA in the PR) to Sahel, and GHA will run tests and deploy code merged to `master` to the staging site and code merged to `deploy` to the production site.

Most of this will be moot in the near future because we'll be moving to Heroku, but the GitHub Actions workflow will be useful, because that's our test runner of choice for Heroku deployments.

## Testing instructions

- Confirm the new build via GitHub Actions succeeds. Also confirm that Travis does not run tests.