### PR TITLE
Fix typo in violation result date formatting, closes #756

### DIFF
--- a/sfm_pc/settings.py
+++ b/sfm_pc/settings.py
@@ -44,22 +44,10 @@ try:
 except ImportError:
     EXTRA_DEBUG_TOOLBAR_PANELS = []
 
-
-try:
-    from .settings_local import DATABASE_URL, GOOGLE_MAPS_KEY, \
-        SECRET_KEY, DEBUG, ALLOWED_HOSTS, IMPORTER_USER, SOLR_URL, \
-        CACHES, OSM_API_KEY, HAYSTACK_CONNECTIONS, \
-        HAYSTACK_DOCUMENT_FIELD, HAYSTACK_SIGNAL_PROCESSOR
-except ImportError as e:
-    raise Exception('''DATABASE_URL,
-                     GOOGLE_MAPS_KEY,
-                     SECRET_KEY,
-                     ALLOWED_HOSTS,
-                     IMPORTER_USER,
-                     SOLR_URL,
-                     CACHES,
-                     OSM_API_KEY,
-                     and DEBUG must be defined in settings_local.py''')
+from .settings_local import DATABASE_URL, GOOGLE_MAPS_KEY, \
+    SECRET_KEY, DEBUG, ALLOWED_HOSTS, IMPORTER_USER, SOLR_URL, \
+    CACHES, OSM_API_KEY, HAYSTACK_CONNECTIONS, \
+    HAYSTACK_DOCUMENT_FIELD, HAYSTACK_SIGNAL_PROCESSOR
 
 # Application definition
 

--- a/templates/partials/violation_list_table.html
+++ b/templates/partials/violation_list_table.html
@@ -47,13 +47,13 @@
                     <!-- Start date -->
                     <td>
                         {% if object.start_date %}
-                            {{ object.start_date|date:"n F Y" }}
+                            {{ object.start_date|date:"d F Y" }}
                         {% endif %}
                     </td>
                     <!-- End date -->
                     <td>
                         {% if object.end_date %}
-                            {{ object.end_date|date:"n F Y" }}
+                            {{ object.end_date|date:"d F Y" }}
                         {% endif %}
                     </td>
                     <!-- Description -->


### PR DESCRIPTION
## Overview

See title.

Closes #756

## Testing Instructions

Tested locally by running the app, viewing the violation search results, and clicking through to violations to confirm the result dates matched the incident dates.
