### PR TITLE
Deduplicate source lists on entity detail pages, update column headers

### DIFF
--- a/sfm_pc/utils.py
+++ b/sfm_pc/utils.py
@@ -880,5 +880,3 @@ def get_source_context(field_name, access_point, uncommitted=True):
         context['accessed_on'] = access_point.accessed_on.strftime('%Y-%m-%dT%H:%M:%S')
 
     return context
-
-

--- a/source/models.py
+++ b/source/models.py
@@ -46,7 +46,7 @@ class Source(models.Model, GetSpreadsheetFieldNameMixin, VersionsMixin):
     title = source_fields.TextField(verbose_name=_("title"), spreadsheet_field_name='source:title')
     type = source_fields.CharField(max_length=1000, null=True, blank=True, spreadsheet_field_name='source:type')
     author = source_fields.CharField(max_length=1000, null=True, blank=True, spreadsheet_field_name='source:author')
-    publication = source_fields.TextField(null=True, verbose_name=_("publication"), spreadsheet_field_name='source:publication_name')
+    publication = source_fields.TextField(null=True, verbose_name=_("publisher"), spreadsheet_field_name='source:publication_name')
     publication_country = source_fields.CharField(
         max_length=1000,
         verbose_name=_("publication country"),

--- a/templates/partials/source_overview_table.html
+++ b/templates/partials/source_overview_table.html
@@ -44,7 +44,7 @@
                             {{ source.title }}
                         </a>
                     </td>
-                    {% with access_date=source.accesspoint_set.get.accessed_on %}
+                    {% with access_date=source.accesspoint_set.last.accessed_on %}
                         <td data-order="{{ access_date.year|default:0 }}-{{ access_date.month|default:0 }}-{{access_date.day|default:0 }}">
                             {% if access_date.month and access_date.day %}
                                 {{ access_date|date:"d F Y" }}
@@ -57,9 +57,9 @@
                     {% endwith %}
                     <td>
                         <a
-                            href="{{ source.accesspoint_set.get.archive_url }}"
+                            href="{{ source.accesspoint_set.last.archive_url }}"
                             target="_blank"
-                            onclick="_paq.push(['trackEvent', 'Source Table Interaction', 'Archive Link Click', '{{ source.accesspoint_set.get.archive_url }}']);"
+                            onclick="_paq.push(['trackEvent', 'Source Table Interaction', 'Archive Link Click', '{{ source.accesspoint_set.last.archive_url }}']);"
                         >
                             <i class="fas fa-link"></i>
                         </a>

--- a/templates/partials/source_overview_table.html
+++ b/templates/partials/source_overview_table.html
@@ -15,7 +15,7 @@
                     <th>{{ models.Source|verbose_field_name:"publication" }}</th>
                     <th>{{ models.Source|verbose_field_name:"title" }}</th>
                     <th>{{ models.AccessPoint|verbose_field_name:"accessed_on" }}</th>
-                    <th>Permalink</th>
+                    <th>Archive Link</th>
                 </tr>
             </thead>
             <tbody>

--- a/violation/views.py
+++ b/violation/views.py
@@ -23,11 +23,8 @@ class ViolationDetail(BaseDetailView):
     slug_field = 'uuid'
 
     def get_sources(self, context):
-        return sorted(
-            context['violation'].sources,
-            key=lambda x: x.get_published_date() or date.min,
-            reverse=True
-        )
+        return context['violation'].sources.order_by('source_url', '-accesspoint__accessed_on')\
+                                           .distinct('source_url')
 
     def get_page_title(self):
         title = _('Incident')


### PR DESCRIPTION
## Overview

See title.

Connects #760, #764

### Demo

![Screen Shot 2021-06-10 at 1 40 18 PM](https://user-images.githubusercontent.com/12176173/121579534-6abcee00-c9f1-11eb-9ccf-18f7631a2fe2.png)

### Testing instructions

- Confirm CI passes
- Deploy to staging and confirm source lists on a variety of entity detail pages do not contain duplicates, and that the header matches the demo screenshot, above.