### PR TITLE
Flag invalid published dates

### DIFF
--- a/sfm_pc/management/commands/import_google_doc.py
+++ b/sfm_pc/management/commands/import_google_doc.py
@@ -1432,6 +1432,10 @@ class Command(BaseCommand):
                     else:
                         source_info['{}_timestamp'.format(prefix)] = parsed_date
 
+                    if not parsed_date and prefix == 'published':
+                        message = 'Invalid published_date "{1}" at {2}'.format(prefix, date_val, access_point_uuid)
+                        self.log_error(message, sheet='sources', current_row=idx + 2)
+
                 new_source, created = Source.objects.get_or_create(**source_info)
 
                 AccessPoint.objects.create(

--- a/tests/fixtures/importer/sources.csv
+++ b/tests/fixtures/importer/sources.csv
@@ -111,3 +111,4 @@
 ,,,,"609b2b83-9774-4a8f-9174-9ca4163a2ac6","document","Importer Test Site (Base): Importer Test Organization Alpha Name ",,"https://securityforcemonitor.org",,,"2019-09-17","2019-09-17","page",1,,,"Turks and Caicos","Importer Test Publication A","58980ef1-eaa1-4de5-999e-46ac217e1622"
 ,,,,"fec9dd88-6e80-485e-93a6-f9459aa456b4","document","Importer Test Site: Importer Test Organization Alpha Name ",,,,,,,,,,,,,
 ,,,,"11fcbb82-d4c6-47bc-9904-3155fb681f1a","document","Importer Test Area of Operations: Importer Test Organization Alpha Name",,,,,,,,,,,,,
+"Undated source",,,,"c194c605-0032-4ad8-9f7f-6e7c7f5b9573","document","Source Undated","Source Undated Author","https://securityforcemonitor.org",,,,"2020-01-01","page",1,"https://securityforcemonitor.org","2010-11-25T09:17:46","Turks and Caicos","Importer Test Publication A","58980ef1-eaa1-4de5-999e-46ac217e1621"

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -125,6 +125,35 @@ def test_source_dates_and_timestamps(data_import):
         assert not getattr(timestamp_src, date_field)
         assert getattr(timestamp_src, timestamp_field)
 
+    error_file = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        '..',
+        'sources-errors.csv'
+    )
+
+    # TODO: This contains an extra source because timestamps aren't being
+    # parsed correctly.
+    # Source.objects.get(accesspoint__uuid='15717fdb-7d0f-4720-9766-dc61555588f6')
+    undated_sources = Source.objects.filter(published_date='').values_list('accesspoint__uuid', flat=True)
+
+    undated_source_set = set(str(uuid) for uuid in undated_sources)
+
+    error_source_set = set()
+
+    with open(error_file, 'r') as f:
+        reader = csv.reader(f)
+
+        next(reader)  # discard header
+
+        for record in reader:
+            _, message = record
+            assert message.startswith('Invalid published_date')
+
+            source_id = message.split()[-1]
+            assert source_id in undated_source_set
+            error_source_set.add(source_id)
+
+        assert undated_source_set == error_source_set
 
 @pytest.mark.django_db
 def test_incidents(data_import):

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -125,16 +125,15 @@ def test_source_dates_and_timestamps(data_import):
         assert not getattr(timestamp_src, date_field)
         assert getattr(timestamp_src, timestamp_field)
 
+    # Test that invalid published dates are reported as expected
     error_file = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         '..',
         'sources-errors.csv'
     )
 
-    # TODO: This contains an extra source because timestamps aren't being
-    # parsed correctly.
-    # Source.objects.get(accesspoint__uuid='15717fdb-7d0f-4720-9766-dc61555588f6')
-    undated_sources = Source.objects.filter(published_date='').values_list('accesspoint__uuid', flat=True)
+    undated_sources = Source.objects.filter(published_date='', published_timestamp__isnull=True)\
+                                    .values_list('accesspoint__uuid', flat=True)
 
     undated_source_set = set(str(uuid) for uuid in undated_sources)
 


### PR DESCRIPTION
## Overview

This PR adds logic to log an error when a source is missing a published date. It also expands the source date import test to ensure we're getting messages when we expect them, and not when we don't.

Connects #763

### Notes

We should test this with an actual import.

## Testing Instructions

* Confirm CI passes
* tk