### PR TITLE
Resolve duplicate memberships, superiors/subordinates, and areas of operation

### DIFF
--- a/association/models.py
+++ b/association/models.py
@@ -9,11 +9,11 @@ from complex_fields.models import ComplexField, ComplexFieldContainer
 from complex_fields.base_models import BaseModel
 from organization.models import Organization
 from location.models import Location
-from sfm_pc.models import GetComplexFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin, SuperlativeDateMixin
 from source.mixins import SourcesMixin
 
 
-class Association(models.Model, BaseModel, SourcesMixin, GetComplexFieldNameMixin):
+class Association(models.Model, BaseModel, SourcesMixin, SuperlativeDateMixin, GetComplexFieldNameMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.startdate = ComplexFieldContainer(self, AssociationStartDate)

--- a/emplacement/models.py
+++ b/emplacement/models.py
@@ -13,11 +13,11 @@ from complex_fields.models import (ComplexField, ComplexFieldContainer,
 from complex_fields.base_models import BaseModel
 from organization.models import Organization
 from location.models import Location
-from sfm_pc.models import GetComplexFieldNameMixin
+from sfm_pc.models import GetComplexFieldNameMixin, SuperlativeDateMixin
 from source.mixins import SourcesMixin
 
 
-class Emplacement(models.Model, BaseModel, SourcesMixin, GetComplexFieldNameMixin):
+class Emplacement(models.Model, BaseModel, SourcesMixin, SuperlativeDateMixin, GetComplexFieldNameMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.startdate = ComplexFieldContainer(self, EmplacementStartDate)

--- a/organization/models.py
+++ b/organization/models.py
@@ -3,6 +3,7 @@ import uuid
 import reversion
 
 from django.db import models
+from django.db.models import Min, Max
 from django.db.models.functions import Coalesce
 from django.utils.translation import ugettext as _
 from django.conf import settings
@@ -85,10 +86,9 @@ class Organization(models.Model, BaseModel, SourcesMixin, VersionsMixin, GetComp
         with nulls last.
         '''
         assocs = self.associationorganization_set\
-                     .annotate(lcd=Coalesce('object_ref__associationstartdate__value',
-                                            'object_ref__associationenddate__value',
-                                            models.Value('1000-0-0')))\
-                     .order_by('-lcd')
+                     .annotate(min_start_date=Min('object_ref__associationstartdate__value'),
+                               max_end_date=Max('object_ref__associationenddate__value'))\
+                     .order_by(Coalesce('min_start_date', 'max_end_date').desc(nulls_last=True))
 
         return assocs
 
@@ -101,10 +101,9 @@ class Organization(models.Model, BaseModel, SourcesMixin, VersionsMixin, GetComp
         with nulls last.
         '''
         empls = self.emplacementorganization_set\
-                    .annotate(lcd=Coalesce('object_ref__emplacementstartdate__value',
-                                           'object_ref__emplacementenddate__value',
-                                           models.Value('1000-0-0')))\
-                    .order_by('-lcd')
+                    .annotate(min_start_date=Min('object_ref__emplacementstartdate__value'),
+                              max_end_date=Max('object_ref__emplacementenddate__value'))\
+                    .order_by(Coalesce('min_start_date', 'max_end_date').desc(nulls_last=True))
 
         return empls
 

--- a/organization/views.py
+++ b/organization/views.py
@@ -167,12 +167,9 @@ class OrganizationDetail(BaseDetailView):
         )
 
         associations = context['organization'].associations
-        context['associations'] = [ass.object_ref for ass in associations]
+        context['associations'] = [a.object_ref for a in associations]
 
-        area_ids = [
-            association.object_ref.area.get_value().value.id
-            for association in associations
-        ]
+        area_ids = associations.values_list('object_ref__associationarea__value')
 
         context['areas'] = serialize(
             'geojson',

--- a/sfm_pc/management/commands/import_google_doc.py
+++ b/sfm_pc/management/commands/import_google_doc.py
@@ -1771,22 +1771,6 @@ class Command(BaseCommand):
                     membership_data['MembershipPerson_MembershipPersonMember']['sources'] += sources
                     membership.update(membership_data)
 
-                except MembershipPerson.MultipleObjectsReturned:
-                    memberships = MembershipPerson.objects.filter(**membership_kwargs)
-                    membership = memberships.order_by('id').first()
-                    duplicates = memberships.exclude(id=membership.id)
-
-                    self.stdout.write('Found {0} duplicate memberships for {1}'.format(duplicates.count(), person))
-                    remove_duplicates = input('Remove duplicates? [y/n] ')
-
-                    if remove_duplicates.lower().strip() == 'y':
-                        delete_summary = duplicates.delete()
-                        self.stdout.write('Removed duplicate memberships for {0}. Summary: {1}'.format(person, delete_summary))
-
-                    sources = set(self.sourcesList(membership, 'member') + self.sourcesList(membership, 'organization'))
-                    membership_data['MembershipPerson_MembershipPersonMember']['sources'] += sources
-                    membership.update(membership_data)
-
                 except MembershipPerson.DoesNotExist:
                     membership = MembershipPerson.create(membership_data)
 

--- a/sfm_pc/management/commands/import_google_doc.py
+++ b/sfm_pc/management/commands/import_google_doc.py
@@ -1728,23 +1728,23 @@ class Command(BaseCommand):
                     lcd = None
 
                 try:
-                    role_name = person_data[membership_positions['Role']['value']]
+                    role_name = person_data[membership_positions['Role']['value']].strip()
                 except IndexError:
                     role = None
                 else:
                     if role_name:
-                        role, _ = Role.objects.get_or_create(value=role_name.strip())
+                        role, _ = Role.objects.get_or_create(value=role_name)
                         role = role.id
                     else:
                         role = None
 
                 try:
-                    rank_name = person_data[membership_positions['Rank']['value']]
+                    rank_name = person_data[membership_positions['Rank']['value']].strip()
                 except IndexError:
                     rank = None
                 else:
                     if rank_name:
-                        rank, _ = Rank.objects.get_or_create(value=rank_name.strip())
+                        rank, _ = Rank.objects.get_or_create(value=rank_name)
                         rank = rank.id
                     else:
                         rank = None

--- a/sfm_pc/models.py
+++ b/sfm_pc/models.py
@@ -76,3 +76,16 @@ class GetComplexFieldNameMixin:
             # If no source field name is specified, the default is usually
             # the spreadsheet field name with ":source" appended on
             return cls.get_spreadsheet_field_name(field_name) + ':source'
+
+
+class SuperlativeDateMixin:
+
+    @property
+    def first_startdate(self):
+        return self.startdate.field_model.objects.filter(object_ref=self)\
+                                                 .order_by('value').first()
+
+    @property
+    def last_enddate(self):
+        return self.enddate.field_model.objects.filter(object_ref=self)\
+                                               .order_by('-value').first()

--- a/templates/organization/view.html
+++ b/templates/organization/view.html
@@ -136,12 +136,12 @@
                         {% endif %}
                         </td>
                         <td class="cited">
-                            {% datetype association.startdate.get_value 'start' %}
-                            {% cite association.startdate.get_value %}
+                            {% datetype association.first_startdate 'start' %}
+                            {% cite association.first_startdate %}
                         </td>
                         <td class="cited">
-                            {% datetype association.enddate.get_value 'end' %}
-                            {% cite association.enddate.get_value %}
+                            {% datetype association.last_enddate 'end' %}
+                            {% cite association.last_enddate %}
                         </td>
                     </td>
                 {% endfor %}
@@ -190,12 +190,12 @@
                             {% cite emplacement.site.get_value %}
                         </td>
                         <td class="cited">
-                            {% datetype emplacement.startdate.get_value 'start' %}
-                            {% cite emplacement.startdate.get_value %}
+                            {% datetype emplacement.first_startdate 'start' %}
+                            {% cite emplacement.first_startdate %}
                         </td>
                         <td class="cited">
-                            {% datetype emplacement.enddate.get_value 'end' %}
-                            {% cite emplacement.enddate.get_value %}
+                            {% datetype emplacement.last_enddate 'end' %}
+                            {% cite emplacement.last_enddate %}
                         </td>
                     </td>
                 {% endfor %}


### PR DESCRIPTION
## Overview

This PR resolves three bugs that manifested as duplicates in the user interface:

1. Updates the import so that actual duplicate memberships are not created (See https://github.com/security-force-monitor/sfm-cms/issues/697#issuecomment-910428898)
2. Updates the person view to retrieve a distinct list of organizations to which a person belongs, in order to retrieve superiors and subordinates without duplicating them (Again, see https://github.com/security-force-monitor/sfm-cms/issues/697#issuecomment-910428898)
3. Updates the sort methodology for areas and emplacements so locations cannot be potentially multiplied due to multiple start/end dates (See https://github.com/security-force-monitor/sfm-cms/issues/774#issuecomment-910631556)

Connects #697, #774.

## Testing Instructions

* Confirm CI passes.
