### PR TITLE
add . to PHONY

### DIFF
--- a/docket.mk
+++ b/docket.mk
@@ -1,4 +1,4 @@
-PHONY: sfm_pc/management/commands/country_data
+.PHONY: sfm_pc/management/commands/country_data
 
 %_import : %.csv sfm_pc/management/commands/country_data
 	perl -pe "s/,/ /g" $< | \


### PR DESCRIPTION
## Overview

Fixes failing import.

### Notes
The `.PHONY` target was missing the critical `.`. This caused dependency to skip whenever the import re-ran if the dependency was already built, even if it didn't create all the necessary files in the dependency's target. If make skips the dependency and data is missing, then the process will error out. The `.PHONY` target tells make to rebuild the target so it never skips.

🙄

## Testing Instructions
- run `docker-compose run --rm app make -e ma_cc_import` and force quit the command.
  - previously, make would consider this target built
- run `docker-compose run --rm app make -e ye_cc_import` and confirm it doesn't fail when importing any of the data files.
  - this should work without failure