### PR TITLE
remove zip archive after uploading to s3

### DIFF
--- a/docket.mk
+++ b/docket.mk
@@ -2,6 +2,7 @@
 
 DATA_ARCHIVE_BUCKET := $(shell cat configs/s3_config.json | jq -r '.data_archive_bucket')
 
+.PHONY : data_archive
 data_archive : wwic_download.zip
 	aws s3 cp $< s3://$(DATA_ARCHIVE_BUCKET)/
 	rm $<

--- a/docket.mk
+++ b/docket.mk
@@ -4,6 +4,7 @@ DATA_ARCHIVE_BUCKET := $(shell cat configs/s3_config.json | jq -r '.data_archive
 
 data_archive : wwic_download.zip
 	aws s3 cp $< s3://$(DATA_ARCHIVE_BUCKET)/
+	rm $<
 
 .PHONY: wwic_download.zip
 wwic_download.zip : filtered_data data/wwic_download/metadata/sfm_research_handbook.pdf


### PR DESCRIPTION
## Overview
Fixes a bug found on staging.

If the zip already existed in the file system, it would piling the new data onto the zip and not overwrite the existing zip (?). This had a weird side effect of not adding the new data (?). Zip weirdness?

To fix, I just removed the zip after uploading the archive to s3.

## Testing Instructions
I've tested in my local environment that this fix works by running the data_archive piece of the pipeline on a small subset of the import docket. You can download the data from the staging site to verify that the data isn't empty: https://back.securityforcemonitor.org/en/download/